### PR TITLE
:sparkles: feature: tanstack query wrapper 예시

### DIFF
--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -1,0 +1,151 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/apiClient.browser';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+interface TODO {
+  id: number;
+  title: string;
+  done: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+// base 타입 하나만 정의
+interface Goal {
+  id: number;
+  teamId: string;
+  userId: number;
+  title: string;
+  completedCount: number;
+  todoCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+  todos: TODO[];
+}
+
+// GET 목록 응답 - 제네릭 공통 래퍼로
+export interface PaginatedResponse<T> {
+  goals: T[];
+  nextCursor: number | null;
+  totalCount: number;
+}
+
+// POST 응답 - Goal에서 필요한 것만 Pick
+export type GoalResponse = Pick<
+  Goal,
+  'id' | 'teamId' | 'userId' | 'title' | 'createdAt' | 'updatedAt'
+>;
+
+// POST 요청 body - Goal에서 필요한 것만 Pick
+type CreateGoalPayload = Pick<Goal, 'title'>;
+// DELETE 요청 body - Goal에서 필요한 것만 Pick
+type DeleteGoalPayload = Pick<Goal, 'id'>;
+// PATCH 요청 body - Goal에서 필요한 것만 Pick
+type PatchGoalPayload = Pick<Goal, 'id' | 'title'>;
+
+const GOAL = 'goal';
+const GOALS = 'goals';
+const GOALS_URL = '/goals';
+
+// Pick 원하는 값만 꺼내서 사용
+export const useGetGoals = () => {
+  return useQuery({
+    queryKey: [GOALS],
+    queryFn: async () => {
+      const data: PaginatedResponse<
+        Pick<
+          Goal,
+          | 'id'
+          | 'teamId'
+          | 'userId'
+          | 'title'
+          | 'todoCount'
+          | 'completedCount'
+          | 'createdAt'
+          | 'updatedAt'
+        >
+      > =
+        await apiClient<
+          PaginatedResponse<
+            Pick<
+              Goal,
+              | 'id'
+              | 'teamId'
+              | 'userId'
+              | 'title'
+              | 'todoCount'
+              | 'completedCount'
+              | 'createdAt'
+              | 'updatedAt'
+            >
+          >
+        >(GOALS_URL);
+      return data;
+    },
+  });
+};
+
+// 예시를 한 페이지에서 전부 보여주기 위해서 enable 옵션을 사용했는데 , 사용하지 않아도 됩니다.
+// Omit 원하는 값만 제외해서 사용
+export const useGetGoal = ({ id }: { id: number }) => {
+  return useQuery({
+    queryKey: [GOAL, id],
+    queryFn: async () => {
+      const data: Omit<Goal, 'completedCount' | 'todoCount'> = await apiClient<
+        Omit<Goal, 'completedCount' | 'todoCount'>
+      >(`${GOALS_URL}/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+};
+
+export const usePostGoals = (options: { onSuccess?: (response: GoalResponse) => void }) => {
+  const queryClient: QueryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: CreateGoalPayload) => {
+      const data: GoalResponse = await apiClient<GoalResponse>(GOALS_URL, {
+        method: 'POST',
+        body: payload,
+      });
+      return data;
+    },
+    ...options,
+    onSuccess: (data: GoalResponse) => {
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
+      options?.onSuccess?.(data);
+    },
+  });
+};
+
+export const useDeleteGoals = () => {
+  const queryClient: QueryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: DeleteGoalPayload) => {
+      const data: GoalResponse = await apiClient<GoalResponse>(`${GOALS_URL}/${payload.id}`, {
+        method: 'DELETE',
+      });
+      return data;
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
+    },
+  });
+};
+
+export const usePatchGoals = () => {
+  const queryClient: QueryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: PatchGoalPayload) => {
+      const data: GoalResponse = await apiClient<GoalResponse>(`${GOALS_URL}/${payload.id}`, {
+        method: 'PATCH',
+        body: { title: payload.title },
+      });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
+    },
+  });
+};

--- a/src/app/(routers)/(todo)/goals/page.tsx
+++ b/src/app/(routers)/(todo)/goals/page.tsx
@@ -1,3 +1,84 @@
+'use client';
+
+import type { GoalResponse } from '@/api/goals';
+
+import { useState } from 'react';
+import { useDeleteGoals, useGetGoal, useGetGoals, usePatchGoals, usePostGoals } from '@/api/goals';
+
+import { Button } from '@/components/ui/button';
+
 export default function Page() {
-  return <div>goal page</div>;
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editTitle, setEditTitle] = useState<string>('');
+  const [goalId, setGoalId] = useState<number | null>(null);
+
+  const { data } = useGetGoals();
+  const { data: goalDetail, isLoading: isDetailLoading } = useGetGoal({ id: goalId! });
+  const { mutate } = usePostGoals({
+    onSuccess: (data: GoalResponse) => alert(`Goal ${data.title} 셍성 완료`),
+  });
+  const { mutate: patchGoals } = usePatchGoals();
+  const { mutate: deleteGoals } = useDeleteGoals();
+
+  return (
+    <div className="h-full w-fit space-y-2 bg-white p-4">
+      goal page
+      <div className="h-fit w-fit space-y-2 p-4">
+        {data?.goals.map((item) => (
+          <div
+            className="flex h-20 w-200 items-center space-x-2 rounded-sm border border-orange-500"
+            key={item.id}
+          >
+            <p>{item.id}</p>
+            {editId !== item.id ? (
+              <>
+                <p>{item.title}</p>
+                <Button onClick={() => setGoalId(goalId === item.id ? null : item.id)}>
+                  {goalId === item.id ? '닫기' : '상세보기'}
+                </Button>
+                <Button onClick={() => deleteGoals({ id: item.id })}>삭제하기</Button>
+                <Button
+                  onClick={() => {
+                    setEditId(item.id);
+                    setEditTitle(item.title);
+                  }}
+                >
+                  값 수정하기
+                </Button>
+              </>
+            ) : (
+              <>
+                <input value={editTitle} onChange={(e) => setEditTitle(e.target.value)} />
+                <Button
+                  onClick={() => {
+                    patchGoals({ id: item.id, title: editTitle });
+                    setEditId(null);
+                  }}
+                >
+                  변경하기
+                </Button>
+                <Button onClick={() => setEditId(null)}>취소</Button>
+              </>
+            )}
+
+            {/* 상세보기 영역 */}
+            {goalId === item.id && (
+              <div className="ml-4 rounded border border-gray-300 p-2 text-sm">
+                {isDetailLoading ? (
+                  <p>로딩 중...</p>
+                ) : (
+                  <>
+                    <p>ID: {goalDetail?.id}</p>
+                    <p>제목: {goalDetail?.title}</p>
+                    <p>생성일: {String(goalDetail?.createdAt)}</p>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <Button onClick={() => mutate({ title: '전교 1등하기' })}>추가하기</Button>
+    </div>
+  );
 }


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.
`apiClient`를 활용한 Goals CRUD API 훅 사용 예시 및 구현입니다.

- **관련 이슈:** Closes #119  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?

- `useGetGoals` — Goals 목록 조회 훅 구현 (페이지네이션 응답 타입 적용)
- `useGetGoal` — Goal 단건 조회 훅 구현 (`enabled` 옵션으로 조건부 요청)
- `usePostGoals` — Goal 생성 훅 구현 (성공 시 목록 자동 갱신)
- `usePatchGoals` — Goal 수정 훅 구현
- `useDeleteGoals` — Goal 삭제 훅 구현
- Goals CRUD 동작 확인을 위한 예시 페이지 구
> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

- 공통 `apiClient`를 통해 BFF 프록시(`/api/proxy`)를 경유하도록 구현
- `Pick` / `Omit` 유틸리티 타입으로 base 타입 하나에서 요청/응답 타입을 파생시켜 중복 타입 정의 최소화
- `PaginatedResponse<T>` 제네릭 래퍼를 공통으로 정의해 다른 도메인에서도 재사용 가능하도록 설계
- `queryKey`에 `id`를 포함해 단건 조회 캐시가 항목별로 독립적으로 관리되도록 처리
<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 개발 서버 실행 (pnpm dev)
2. /goals 페이지 접속
3. 목록 조회 확인
4. '추가하기' 버튼 클릭 → 목록 자동 갱신 확인
5. '값 수정하기' 클릭 → 해당 항목만 input으로 전환 확인
6. '변경하기' 클릭 → 수정 반영 및 목록 갱신 확인
7. '삭제하기' 클릭 → 항목 삭제 및 목록 갱신 확인
8. '상세보기' 클릭 → 단건 조회 데이터 표시 확인
```

**예상 결과:**
- 각 CRUD 동작 후 목록이 자동으로 갱신됨
- 수정 모드가 클릭한 항목에만 적용됨
- 상세보기는 해당 항목 클릭 시에만 API 요청 발생
---

## ⚠️ 리뷰어 참고사항

- 예시용 페이지이므로 로딩/에러 상태 UI는 미구현 상태입니다. 실제 도입 시 추가 필요합니다.
- `console.log`가 일부 남아있습니다. 예시 확인 후 제거 예정입니다.
---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 목표 관리 기능이 완전히 구현되었습니다. 목표 목록 조회, 새로운 목표 추가, 상세 정보 조회, 제목 편집, 삭제 기능을 이용할 수 있습니다.
  * 각 목표별 상세 보기 및 인라인 편집 모드가 추가되었습니다.
  * 실시간 로딩 상태 피드백이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->