### PR TITLE
Feat/126 goal delete edit api

### DIFF
--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -129,8 +129,9 @@ export const useDeleteGoals = (options: { onSuccess?: () => void }) => {
     },
     ...options,
     onSuccess: (_, payload) => {
+      const id = payload.id;
       queryClient.invalidateQueries({ queryKey: [GOALS] });
-      queryClient.invalidateQueries({ queryKey: [GOAL, payload.id] });
+      queryClient.invalidateQueries({ queryKey: [GOAL, id] });
       options?.onSuccess?.();
     },
   });
@@ -147,8 +148,9 @@ export const usePatchGoals = () => {
       return data;
     },
     onSuccess: (_, payload) => {
+      const id = payload.id;
       queryClient.invalidateQueries({ queryKey: [GOALS] });
-      queryClient.invalidateQueries({ queryKey: [GOAL, payload.id] });
+      queryClient.invalidateQueries({ queryKey: [GOAL, id] });
     },
   });
 };

--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -11,7 +11,7 @@ interface TODO {
   updatedAt: Date;
 }
 // base 타입 하나만 정의
-interface Goal {
+export interface Goal {
   id: number;
   teamId: string;
   userId: number;
@@ -118,7 +118,7 @@ export const usePostGoals = (options: { onSuccess?: (response: GoalResponse) => 
   });
 };
 
-export const useDeleteGoals = () => {
+export const useDeleteGoals = (options: { onSuccess?: (response: GoalResponse) => void }) => {
   const queryClient: QueryClient = useQueryClient();
   return useMutation({
     mutationFn: async (payload: DeleteGoalPayload) => {
@@ -127,9 +127,10 @@ export const useDeleteGoals = () => {
       });
       return data;
     },
-
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [GOALS] });
+    ...options,
+    onSuccess: (data: GoalResponse, payload) => {
+      queryClient.invalidateQueries({ queryKey: [GOALS, payload.id] });
+      options?.onSuccess?.(data);
     },
   });
 };
@@ -144,8 +145,9 @@ export const usePatchGoals = () => {
       });
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (_, payload) => {
       queryClient.invalidateQueries({ queryKey: [GOALS] });
+      queryClient.invalidateQueries({ queryKey: [GOAL, payload.id] });
     },
   });
 };

--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -1,3 +1,4 @@
+import type { PaginatedResponse } from '@/api/response';
 import type { QueryClient } from '@tanstack/react-query';
 
 import { apiClient } from '@/lib/apiClient.browser';
@@ -7,8 +8,8 @@ interface TODO {
   id: number;
   title: string;
   done: boolean;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 }
 // base 타입 하나만 정의
 export interface Goal {
@@ -18,16 +19,9 @@ export interface Goal {
   title: string;
   completedCount: number;
   todoCount: number;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
   todos: TODO[];
-}
-
-// GET 목록 응답 - 제네릭 공통 래퍼로
-export interface PaginatedResponse<T> {
-  goals: T[];
-  nextCursor: number | null;
-  totalCount: number;
 }
 
 // POST 응답 - Goal에서 필요한 것만 Pick

--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -118,7 +118,7 @@ export const usePostGoals = (options: { onSuccess?: (response: GoalResponse) => 
   });
 };
 
-export const useDeleteGoals = (options: { onSuccess?: (response: GoalResponse) => void }) => {
+export const useDeleteGoals = (options: { onSuccess?: () => void }) => {
   const queryClient: QueryClient = useQueryClient();
   return useMutation({
     mutationFn: async (payload: DeleteGoalPayload) => {
@@ -128,9 +128,10 @@ export const useDeleteGoals = (options: { onSuccess?: (response: GoalResponse) =
       return data;
     },
     ...options,
-    onSuccess: (data: GoalResponse, payload) => {
-      queryClient.invalidateQueries({ queryKey: [GOALS, payload.id] });
-      options?.onSuccess?.(data);
+    onSuccess: (_, payload) => {
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
+      queryClient.invalidateQueries({ queryKey: [GOAL, payload.id] });
+      options?.onSuccess?.();
     },
   });
 };

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -1,0 +1,6 @@
+export type PaginatedResponse<T, K extends string = 'goals'> = {
+  [key in K]: T[];
+} & {
+  nextCursor: number | null;
+  totalCount: number;
+};

--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -1,0 +1,93 @@
+import type { Goal } from '@/api/goals';
+
+import { apiClient } from '@/lib/apiClient.browser';
+import { useQuery } from '@tanstack/react-query';
+
+export interface Tag {
+  id: number;
+  title: string;
+}
+
+export interface Todo {
+  id: number;
+  teamId: string;
+  userId: number;
+  goalId: number;
+  title: string;
+  done: boolean;
+  fileUrl: string | null;
+  linkUrl: string | null;
+  dueDate: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  goal: Pick<Goal, 'id' | 'title'>;
+  noteIds: number[];
+  tags: Tag[];
+}
+
+export type PaginatedResponse<T, K extends string = 'todos'> = {
+  [key in K]: T[];
+} & {
+  nextCursor: number | null;
+  totalCount: number;
+};
+
+const TODOS = 'todos';
+// const TODO = 'todo';
+const TODOS_URL = '/todos';
+
+interface GetTodosParams {
+  goalId?: number;
+  done?: boolean;
+  limit?: number;
+  cursor?: number;
+}
+
+export interface Favorite {
+  id: number;
+  teamId: string;
+  userId: number;
+  todoId: number;
+  createdAt: Date;
+  todo: Pick<Todo, 'id' | 'title' | 'done' | 'goal'>;
+}
+
+// 기존 Todo 타입에 isFavorite 추가된 버전
+export type TodoWithFavorites = Todo & { favorites: boolean };
+
+// useGetTodos 반환 response 타입
+export type TodosWithFavoriteResponse = PaginatedResponse<TodoWithFavorites>;
+
+export const useGetTodos = ({ goalId, done, limit, cursor }: GetTodosParams) => {
+  return useQuery({
+    queryKey: [TODOS, { goalId, done, limit, cursor }],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (goalId !== undefined) params.append('goalId', String(goalId));
+      if (done !== undefined) params.append('done', String(done));
+      if (limit !== undefined) params.append('limit', String(limit));
+      if (cursor !== undefined) params.append('cursor', String(cursor));
+
+      const queryString = params.toString();
+      const url = queryString ? `${TODOS_URL}?${queryString}` : TODOS_URL;
+
+      // 두 개 병렬 요청
+      const [todosData, favoritesData] = await Promise.all([
+        apiClient<PaginatedResponse<Todo>>(url),
+        apiClient<PaginatedResponse<Favorite, 'favorites'>>(`${TODOS_URL}/favorites`),
+      ]);
+
+      // favorites의 todoId만 Set으로 추출 (O(1) 조회)
+      const favoriteTodoIds = new Set(favoritesData.favorites.map((f) => f.todoId));
+      const todosWithFavorite = todosData.todos.map((todo) => ({
+        ...todo,
+        favorites: favoriteTodoIds.has(todo.id),
+      }));
+
+      return {
+        ...todosData,
+        todos: todosWithFavorite,
+      };
+    },
+  });
+};

--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -1,4 +1,5 @@
 import type { Goal } from '@/api/goals';
+import type { PaginatedResponse } from '@/api/response';
 
 import { apiClient } from '@/lib/apiClient.browser';
 import { useQuery } from '@tanstack/react-query';
@@ -17,20 +18,13 @@ export interface Todo {
   done: boolean;
   fileUrl: string | null;
   linkUrl: string | null;
-  dueDate: Date;
-  createdAt: Date;
-  updatedAt: Date;
+  dueDate: string;
+  createdAt: string;
+  updatedAt: string;
   goal: Pick<Goal, 'id' | 'title'>;
   noteIds: number[];
   tags: Tag[];
 }
-
-export type PaginatedResponse<T, K extends string = 'todos'> = {
-  [key in K]: T[];
-} & {
-  nextCursor: number | null;
-  totalCount: number;
-};
 
 const TODOS = 'todos';
 // const TODO = 'todo';
@@ -48,7 +42,7 @@ export interface Favorite {
   teamId: string;
   userId: number;
   todoId: number;
-  createdAt: Date;
+  createdAt: string;
   todo: Pick<Todo, 'id' | 'title' | 'done' | 'goal'>;
 }
 
@@ -56,7 +50,7 @@ export interface Favorite {
 export type TodoWithFavorites = Todo & { favorites: boolean };
 
 // useGetTodos 반환 response 타입
-export type TodosWithFavoriteResponse = PaginatedResponse<TodoWithFavorites>;
+export type TodosWithFavoriteResponse = PaginatedResponse<TodoWithFavorites, 'todos'>;
 
 export const useGetTodos = ({ goalId, done, limit, cursor }: GetTodosParams) => {
   return useQuery({
@@ -73,7 +67,7 @@ export const useGetTodos = ({ goalId, done, limit, cursor }: GetTodosParams) => 
 
       // 두 개 병렬 요청
       const [todosData, favoritesData] = await Promise.all([
-        apiClient<PaginatedResponse<Todo>>(url),
+        apiClient<PaginatedResponse<Todo, 'todos'>>(url),
         apiClient<PaginatedResponse<Favorite, 'favorites'>>(`${TODOS_URL}/favorites`),
       ]);
 

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalsInnerTab.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalsInnerTab.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import noteImage from '@/../public/images/large-note.svg';
+import { useGetGoal } from '@/api/goals';
+import GoalsInnerTabSkeleton from '@/app/(routers)/(todo)/goals/[goalId]/_components/GoalsInnerTabSkeleton';
+import GoalsTab from '@/app/(routers)/(todo)/goals/[goalId]/_components/GoalsTab';
+import TotalListTab from '@/app/(routers)/(todo)/goals/[goalId]/_components/TotalListTab';
+
+import { DonutProgress } from '@/components/common/DonutProgress';
+import { Icon } from '@/components/icon/Icon';
+
+export default function GoalsInnerTab({ goalId }: { goalId: number }) {
+  const { data, isLoading, isSuccess } = useGetGoal({ id: goalId });
+
+  const todoCount: number = data?.todos.filter((todo) => todo.done).length ?? 0;
+  const totalCount: number = data?.todos.length ?? 0;
+  const progressPercent = totalCount === 0 ? 0 : Math.round((todoCount / totalCount) * 100);
+
+  if (isLoading) return <GoalsInnerTabSkeleton />;
+  if (isSuccess)
+    return (
+      <>
+        <div className="w-full space-y-4 md:space-y-6 lg:flex lg:space-x-8">
+          {/*흰색 목표 표기*/}
+          <GoalsTab goalId={goalId} data={data} />
+          <div className="flex flex-col space-y-4 md:flex-row md:space-x-5 lg:w-1/2 lg:flex-row lg:space-y-0 lg:space-x-6">
+            {/*목표 진행도*/}
+            <div className="flex h-40 w-full items-center justify-center space-x-8 rounded-[16px] bg-orange-500 text-white hover:shadow-2xl hover:shadow-orange-300 lg:w-1/2">
+              <DonutProgress trackColor="#FFA96C" value={progressPercent} />
+              <div className="flex flex-col items-center justify-start">
+                <h3 className="font-lg-bold">목표 진행도</h3>
+                <p className="display-lg-bold">
+                  {progressPercent}
+                  <span className="font-xl-medium mr-1">%</span>
+                </p>
+              </div>
+            </div>
+            {/*노트 모아보기*/}
+            <Link
+              href={`/goals/${goalId}/notes`}
+              className="relative h-40 w-full rounded-[16px] bg-blue-200 text-white hover:shadow-2xl hover:shadow-blue-100 lg:w-1/2"
+            >
+              <Image
+                src={noteImage}
+                alt="note image for note page route"
+                width={122}
+                height={122}
+                className="absolute right-2 bottom-5 object-contain"
+              />
+              <div className="absolute bottom-8 left-10 flex items-center justify-center">
+                <h3 className="font-2xl-bold">노트 모아보기</h3>
+                <Icon name="arrow" variant="white" direction="right" />
+              </div>
+            </Link>
+          </div>
+        </div>
+        {/*할일탭*/}
+        <TotalListTab goalId={goalId} />
+      </>
+    );
+}

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalsInnerTabSkeleton.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalsInnerTabSkeleton.tsx
@@ -1,0 +1,18 @@
+export default function GoalsInnerTabSkeleton() {
+  return (
+    <div className="w-full space-y-4 md:space-y-6 lg:flex lg:space-x-8">
+      {/* 흰색 목표 표기 skeleton */}
+      <div className="flex h-16 w-full animate-pulse items-center rounded-[16px] bg-white p-4 lg:h-40 lg:w-1/2">
+        <div className="h-8 w-8 rounded-full bg-gray-200" />
+        <div className="ml-3 h-4 w-40 rounded bg-gray-200" />
+      </div>
+
+      <div className="flex flex-col space-y-4 md:flex-row md:space-x-5 lg:w-1/2 lg:flex-row lg:space-y-0 lg:space-x-6">
+        {/* 목표 진행도 skeleton */}
+        <div className="flex h-40 w-full animate-pulse items-center justify-center space-x-8 rounded-[16px] bg-orange-200 lg:w-1/2" />
+        {/* 노트 모아보기 skeleton */}
+        <div className="h-40 w-full animate-pulse rounded-[16px] bg-blue-100 lg:w-1/2" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalsTab.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalsTab.tsx
@@ -1,11 +1,25 @@
 'use client';
 
-import { useState } from 'react';
+import type { Goal } from '@/api/goals';
+
+import React, { useState } from 'react';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import goalImage from '@/../public/images/small-goal.svg';
+import { useDeleteGoals, usePatchGoals } from '@/api/goals';
 
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { Icon } from '@/components/icon/Icon';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -14,7 +28,21 @@ import {
   SelectTrigger,
 } from '@/components/ui/select';
 
-export default function GoalsTab() {
+interface GoalsTabProps {
+  goalId: number;
+  data: Omit<Goal, 'completedCount' | 'todoCount'>;
+}
+export default function GoalsTab({ goalId, data }: GoalsTabProps) {
+  const router = useRouter();
+
+  const { mutate: deleteGoal } = useDeleteGoals({
+    onSuccess: () => {
+      router.push('/dashboard');
+    },
+  });
+  const { mutate: editGoal } = usePatchGoals();
+  const [title, setTitle] = useState<string>('');
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const selectValue = [
@@ -22,18 +50,31 @@ export default function GoalsTab() {
     { label: '삭제하기', value: 'delete' },
   ];
 
+  const onEditChange = () => {
+    setEditDialogOpen(!editDialogOpen);
+  };
+  const onEditChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setTitle(value);
+  };
   const handleSelectChange = (value: string | null) => {
     if (value === null) return;
     if (value === 'delete') {
-      // '삭제하기'의 value
       setDeleteDialogOpen(true);
+    } else {
+      if (data?.title) {
+        setTitle(data?.title);
+      }
+      setEditDialogOpen(true);
     }
-    // '수정하기'는 여기서 추가 처리
   };
 
   const handleDelete = () => {
-    // 실제 삭제 로직
-    setDeleteDialogOpen(false);
+    deleteGoal({ id: goalId });
+  };
+
+  const onEditConfirm = () => {
+    editGoal({ id: goalId, title: title });
   };
 
   return (
@@ -47,7 +88,7 @@ export default function GoalsTab() {
             height={32}
             className="object-contain"
           />
-          <h2 className="font-base-semibold text-gray-700">자바스크립트로 웹 서비스 만들기</h2>
+          <h2 className="font-base-semibold text-gray-700">{data?.title}</h2>
         </div>
         <Select items={selectValue} onValueChange={handleSelectChange}>
           <SelectTrigger size="sm" iconTrigger>
@@ -56,7 +97,7 @@ export default function GoalsTab() {
           <SelectContent>
             <SelectGroup>
               {selectValue.map((item) => (
-                <SelectItem key={item.value} value={item.value}>
+                <SelectItem size="sm" key={item.value} value={item.value}>
                   {item.label}
                 </SelectItem>
               ))}
@@ -64,6 +105,33 @@ export default function GoalsTab() {
           </SelectContent>
         </Select>
       </div>
+      <Dialog open={editDialogOpen} onOpenChange={onEditChange}>
+        <DialogContent
+          className="w-86 space-y-8 pt-8 md:w-114 md:space-y-10 md:pt-8"
+          showCloseButton={false}
+        >
+          <DialogHeader>
+            <DialogTitle>목표를 수정하시겠습니까 ?</DialogTitle>
+            <Input value={title} onChange={onEditChangeHandler} />
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose
+              render={
+                <Button type="button" variant="ghost" className="w-1/2">
+                  취소
+                </Button>
+              }
+            />
+            <DialogClose
+              render={
+                <Button onClick={onEditConfirm} type="button" variant="default" className="w-1/2">
+                  확인
+                </Button>
+              }
+            />
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <DeleteDialog
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/ItemActionBar.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/ItemActionBar.tsx
@@ -6,16 +6,20 @@ import { Icon } from '@/components/icon/Icon';
 import { Button } from '@/components/ui/button';
 
 export default function ItemActionBar({
+  goalId,
   noteIds,
-  link,
+  linkUrl,
   favorites,
 }: {
+  goalId: number;
   noteIds: number[];
-  link: string | null;
+  linkUrl: string | null;
   favorites: boolean;
 }) {
-  const goalId = 1;
   const router = useRouter();
+  const handleCopyLink = async (linkUrl: string) => {
+    await navigator.clipboard.writeText(linkUrl);
+  };
   return (
     <div className="flex h-fit shrink-0 space-x-[6px] lg:space-x-2">
       <Button
@@ -24,7 +28,6 @@ export default function ItemActionBar({
           if (noteIds.length > 0) {
             router.push(`/goals/${goalId}/notes/${noteIds[0]}`);
           } else {
-            // router.push(`/goals/${goalId}/notes/new`);
             //TODO :이게 맞누 ㅜ
             window.location.href = `/goals/${goalId}/notes/new`;
           }
@@ -35,7 +38,17 @@ export default function ItemActionBar({
       >
         <Icon name="note" variant="orange" />
       </Button>
-      {link && <Icon name="link" variant="orange" />}
+      {linkUrl && (
+        <Button
+          variant="icon"
+          size="none"
+          onClick={() => {
+            linkUrl && handleCopyLink(linkUrl);
+          }}
+        >
+          <Icon name="link" variant="orange" />
+        </Button>
+      )}
       <div className="hidden h-fit shrink-1 space-x-[6px] group-hover:flex lg:space-x-2">
         <Button
           onClick={(e) => {

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/ItemActionBar.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/ItemActionBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { Icon } from '@/components/icon/Icon';
@@ -50,15 +51,17 @@ export default function ItemActionBar({
         </Button>
       )}
       <div className="hidden h-fit shrink-1 space-x-[6px] group-hover:flex lg:space-x-2">
-        <Button
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
-          variant="icon"
-          size="none"
-        >
-          <Icon name="edit" />
-        </Button>
+        <Link href={`/goals/${goalId}/notes/${noteIds[0]}/edit`}>
+          <Button
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            variant="icon"
+            size="none"
+          >
+            <Icon name="edit" />
+          </Button>
+        </Link>
         <Button
           onClick={(e) => {
             e.stopPropagation();

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoList.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoList.tsx
@@ -6,8 +6,15 @@ import { cn } from '@/lib';
 
 import { Icon } from '@/components/icon/Icon';
 
-export default function TodoList({ id, content, done, link, noteIds, favorites }: TodoListProps) {
-  const goalId = 1;
+export default function TodoList({
+  goalId,
+  id,
+  done,
+  title,
+  noteIds,
+  linkUrl,
+  favorites,
+}: TodoListProps) {
   return (
     <div
       className={cn(
@@ -28,11 +35,11 @@ export default function TodoList({ id, content, done, link, noteIds, favorites }
               'hover:font-sm-semibold hover:md:font-base-semibold hover:lg:font-lg-semibold hover:truncate hover:text-orange-500',
             )}
           >
-            {content}
+            {title}
           </p>
         </Link>
       </div>
-      <ItemActionBar noteIds={noteIds} link={link} favorites={favorites} />
+      <ItemActionBar goalId={goalId} noteIds={noteIds} linkUrl={linkUrl} favorites={favorites} />
     </div>
   );
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoSection.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoSection.tsx
@@ -1,6 +1,8 @@
-import type { TodoListProps, TodoSectionProps } from '@/app/(routers)/(todo)/goals/types';
+import type { TodoWithFavorites } from '@/api/todos';
+import type { TodoSectionProps } from '@/app/(routers)/(todo)/goals/types';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import TodoList from '@/app/(routers)/(todo)/goals/[goalId]/_components/TodoList';
 import { cn } from '@/lib';
 
@@ -8,6 +10,7 @@ import { Icon } from '@/components/icon/Icon';
 import { IconButton } from '@/components/ui/button';
 
 export function TodoSection({
+  goalId,
   title,
   todos,
   bgColor,
@@ -21,14 +24,18 @@ export function TodoSection({
         <h3 className="font-base-semibold text-gray-800">{title}</h3>
         {showActions && (
           <div className="flex space-x-2">
-            <IconButton variant="ghost" className="h-10">
-              <Icon name="schedule" size={20} />
-              <span>캘린더 보기</span>
-            </IconButton>
-            <IconButton variant="default" className="h-10">
-              <Icon name="plus" />
-              <span>할 일 추가</span>
-            </IconButton>
+            <Link className="h-fit w-fit" href="/calendar">
+              <IconButton variant="ghost" className="h-10">
+                <Icon name="schedule" size={20} />
+                <span>캘린더 보기</span>
+              </IconButton>
+            </Link>
+            <Link className="h-fit w-fit" href="/goals/todos/new">
+              <IconButton variant="default" className="h-10">
+                <Icon name="plus" />
+                <span>할 일 추가</span>
+              </IconButton>
+            </Link>
           </div>
         )}
       </div>
@@ -40,7 +47,18 @@ export function TodoSection({
           )}
         >
           {todos.length > 0 ? (
-            todos.map((todo: TodoListProps) => <TodoList key={todo.id} {...todo} />)
+            todos.map((todo: TodoWithFavorites) => (
+              <TodoList
+                key={todo.id}
+                goalId={goalId}
+                id={todo.id}
+                done={todo.done}
+                title={todo.title}
+                noteIds={todo.noteIds}
+                linkUrl={todo.linkUrl}
+                favorites={todo.favorites}
+              />
+            ))
           ) : (
             <div className="flex flex-col items-center space-y-2.5">
               <Image

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoSectionSkeleton.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoSectionSkeleton.tsx
@@ -1,0 +1,38 @@
+export function TodoSectionSkeleton({ showActions }: { showActions?: boolean }) {
+  return (
+    <div className="flex h-fit w-full min-w-0 flex-col space-y-[10px]">
+      {/* 헤더 */}
+      <div className="flex h-fit w-full items-center justify-between px-2 lg:h-10">
+        <div className="h-4 w-12 animate-pulse rounded bg-gray-200" />
+        {showActions && (
+          <div className="flex space-x-2">
+            <div className="h-10 w-28 animate-pulse rounded-lg bg-gray-200" />
+            <div className="h-10 w-24 animate-pulse rounded-lg bg-gray-200" />
+          </div>
+        )}
+      </div>
+
+      {/* 리스트 영역 */}
+      <div className="h-49 w-full rounded-[28px] bg-orange-100 px-4 py-5 md:h-80 lg:h-144">
+        <div className="flex h-full w-full flex-col space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex h-9 items-center space-x-2 px-1 md:h-11 md:px-2">
+              {/* 체크박스 */}
+              <div className="h-[18px] w-[18px] shrink-0 animate-pulse rounded bg-gray-200" />
+              {/* 타이틀 - 길이 랜덤하게 */}
+              <div
+                className="h-4 animate-pulse rounded bg-gray-200"
+                style={{ width: `${[40, 55, 70, 50, 65][i % 5]}%` }}
+              />
+              {/* 액션 아이콘들 */}
+              <div className="ml-auto flex space-x-1">
+                <div className="h-5 w-5 animate-pulse rounded bg-gray-200" />
+                <div className="h-5 w-5 animate-pulse rounded bg-gray-200" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/TotalListTab.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/TotalListTab.tsx
@@ -1,154 +1,46 @@
-import type { TodoListProps } from '@/app/(routers)/(todo)/goals/types';
+'use client';
 
+import type { TodoWithFavorites } from '@/api/todos';
+import type { TotalListTabProps } from '@/app/(routers)/(todo)/goals/types';
+
+import { useGetTodos } from '@/api/todos';
 import { TodoSection } from '@/app/(routers)/(todo)/goals/[goalId]/_components/TodoSection';
+import { TodoSectionSkeleton } from '@/app/(routers)/(todo)/goals/[goalId]/_components/TodoSectionSkeleton';
 
-export default function TotalListTab() {
-  const todoLists: TodoListProps[] = [
-    {
-      id: 1,
-      content: '사용자 데이터 렌더링 구현',
-      done: false,
-      link: 'https://www.codeit.kr',
-      noteIds: [1],
-      favorites: true,
-    },
-    {
-      id: 2,
-      content: '개발 폴더 구조 세팅 (src, public, components)',
-      done: false,
-      link: 'https://www.codeit.kr',
-      noteIds: [],
-      favorites: false,
-    },
-    {
-      id: 3,
-      content: '자바스크립트 기초 챕터4 듣기',
-      done: false,
-      link: 'https://www.codeit.kr',
-      noteIds: [1],
-      favorites: false,
-    },
-    {
-      id: 4,
-      content: 'JSON 서버 또는 mock API 연동',
-      done: false,
-      link: 'https://www.codeit.kr',
-      noteIds: [1],
-      favorites: true,
-    },
-    {
-      id: 5,
-      content: '반응형 레이아웃을 설계하고 미디어쿼리를 적용',
-      done: false,
-      link: 'https://www.codeit.kr',
-      noteIds: [],
-      favorites: true,
-    },
-    {
-      id: 6,
-      content: '자바스크립 기초 챕터3기 듣기',
-      done: false,
-      link: null,
-      noteIds: [1],
-      favorites: true,
-    },
-  ];
+export default function TotalListTab({ goalId }: TotalListTabProps) {
+  const { data, isSuccess, isLoading } = useGetTodos({ goalId });
 
-  const todoListsDone: TodoListProps[] = [
-    {
-      id: 7,
-      content: '사용자 데이터 렌더링 구현',
-      done: true,
-      link: 'https://www.codeit.kr',
-      noteIds: [],
-      favorites: true,
-    },
-    {
-      id: 8,
-      content: '개발 폴더 구조 세팅 (src, public, components)',
-      done: true,
-      link: 'https://www.codeit.kr',
-      noteIds: [],
-      favorites: false,
-    },
-    {
-      id: 9,
-      content: '자바스크립트 기초 챕터4 듣기',
-      done: true,
-      link: null,
-      noteIds: [1],
-      favorites: false,
-    },
-    {
-      id: 10,
-      content: 'JSON 서버 또는 mock API 연동',
-      done: true,
-      link: null,
-      noteIds: [],
-      favorites: true,
-    },
-    {
-      id: 11,
-      content: '반응형 레이아웃을 설계하고 미디어쿼리를 적용',
-      done: true,
-      link: 'https://www.codeit.kr',
-      noteIds: [1],
-      favorites: true,
-    },
-    {
-      id: 12,
-      content: '개발 폴더 구조 세팅 (src, public, components)',
-      done: true,
-      link: 'https://www.codeit.kr',
-      noteIds: [],
-      favorites: false,
-    },
-    {
-      id: 13,
-      content: '자바스크립트 기초 챕터4 듣기',
-      done: true,
-      link: 'https://www.codeit.kr',
-      noteIds: [],
-      favorites: false,
-    },
-    {
-      id: 14,
-      content: 'JSON 서버 또는 mock API 연동',
-      done: true,
-      link: 'https://www.codeit.kr',
-      noteIds: [1],
-      favorites: true,
-    },
-    {
-      id: 15,
-      content: '반응형 레이아웃을 설계하고 미디어쿼리를 적용',
-      done: true,
-      link: null,
-      noteIds: [],
-      favorites: true,
-    },
-  ];
+  const todoLists = data?.todos.filter((todo: TodoWithFavorites) => !todo.done) ?? [];
+  const todoListsDone = data?.todos.filter((todo: TodoWithFavorites) => todo.done) ?? [];
 
-  // const todoLists: TodoListProps[] = [];
-  // const todoListsDone: TodoListProps[] = [];
-
-  return (
-    <div className="flex flex-col space-y-4 md:space-y-4 lg:flex-row lg:space-x-8">
-      <TodoSection
-        title="TO DO"
-        todos={todoLists}
-        bgColor="bg-orange-100"
-        emptyImage="/images/big-zero-todo.svg"
-        emptyText="해야할 일이 아직 없어요"
-        showActions
-      />
-      <TodoSection
-        title="DONE"
-        todos={todoListsDone}
-        bgColor="bg-white"
-        emptyImage="/images/big-zero-done.svg"
-        emptyText="완료한 일이 아직 없어요"
-      />
-    </div>
-  );
+  if (isLoading) {
+    return (
+      <div className="flex flex-col space-y-4 md:space-y-4 lg:flex-row lg:space-x-8">
+        <TodoSectionSkeleton showActions />
+        <TodoSectionSkeleton />
+      </div>
+    );
+  }
+  if (isSuccess)
+    return (
+      <div className="flex flex-col space-y-4 md:space-y-4 lg:flex-row lg:space-x-8">
+        <TodoSection
+          goalId={goalId}
+          title="TO DO"
+          todos={todoLists}
+          bgColor="bg-orange-100"
+          emptyImage="/images/big-zero-todo.svg"
+          emptyText="해야할 일이 아직 없어요"
+          showActions
+        />
+        <TodoSection
+          goalId={goalId}
+          title="DONE"
+          todos={todoListsDone}
+          bgColor="bg-white"
+          emptyImage="/images/big-zero-done.svg"
+          emptyText="완료한 일이 아직 없어요"
+        />
+      </div>
+    );
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/page.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/page.tsx
@@ -1,58 +1,14 @@
-import Image from 'next/image';
-import Link from 'next/link';
-import noteImage from '@/../public/images/large-note.svg';
-import GoalsTab from '@/app/(routers)/(todo)/goals/[goalId]/_components/GoalsTab';
-import TotalListTab from '@/app/(routers)/(todo)/goals/[goalId]/_components/TotalListTab';
-
-import { DonutProgress } from '@/components/common/DonutProgress';
-import { Icon } from '@/components/icon/Icon';
+import GoalsInnerTab from '@/app/(routers)/(todo)/goals/[goalId]/_components/GoalsInnerTab';
 
 export default async function GoalId({ params }: { params: Promise<{ goalId: string }> }) {
-  const progressPercent: number = 64;
   const { goalId } = await params;
 
   return (
-    <div className="flex h-full w-86 flex-col space-y-12 overflow-scroll pt-8 pb-14 md:min-w-159 md:space-y-0 md:pt-0 lg:w-265 lg:max-w-328">
-      {/*상단 탭*/}
+    <div className="flex h-full w-86 flex-col space-y-12 pt-8 pb-14 md:min-w-159 md:space-y-0 md:pt-0 lg:w-265 lg:max-w-328">
       <h1 className="font-xl-semibold lg:text-2xl-semibold hidden pt-12 pb-7 text-black md:block md:pt-20 md:pb-10">
         체다치즈님의 목표
       </h1>
-      <div className="w-full space-y-4 md:space-y-6 lg:flex lg:space-x-8">
-        {/*흰색 목표 표기*/}
-        <GoalsTab />
-        <div className="flex flex-col space-y-4 md:flex-row md:space-x-5 lg:w-1/2 lg:flex-row lg:space-y-0 lg:space-x-6">
-          {/*목표 진행도*/}
-          <div className="flex h-40 w-full items-center justify-center space-x-8 rounded-[16px] bg-orange-500 text-white hover:shadow-2xl hover:shadow-orange-300 lg:w-1/2">
-            <DonutProgress trackColor="#FFA96C" value={progressPercent} />
-            <div className="flex flex-col items-center justify-start">
-              <h3 className="font-lg-bold">목표 진행도</h3>
-              <p className="display-lg-bold">
-                {progressPercent}
-                <span className="font-xl-medium mr-1">%</span>
-              </p>
-            </div>
-          </div>
-          {/*노트 모아보기*/}
-          <Link
-            href={`/goals/${goalId}/notes`}
-            className="relative h-40 w-full rounded-[16px] bg-blue-200 text-white hover:shadow-2xl hover:shadow-blue-100 lg:w-1/2"
-          >
-            <Image
-              src={noteImage}
-              alt="note image for note page route"
-              width={122}
-              height={122}
-              className="absolute right-2 bottom-5 object-contain"
-            />
-            <div className="absolute bottom-8 left-10 flex items-center justify-center">
-              <h3 className="font-2xl-bold">노트 모아보기</h3>
-              <Icon name="arrow" variant="white" direction="right" />
-            </div>
-          </Link>
-        </div>
-      </div>
-      {/*할일탭*/}
-      <TotalListTab />
+      <GoalsInnerTab goalId={Number(goalId)} />
     </div>
   );
 }

--- a/src/app/(routers)/(todo)/goals/page.tsx
+++ b/src/app/(routers)/(todo)/goals/page.tsx
@@ -18,7 +18,11 @@ export default function Page() {
     onSuccess: (data: GoalResponse) => alert(`Goal ${data.title} 셍성 완료`),
   });
   const { mutate: patchGoals } = usePatchGoals();
-  const { mutate: deleteGoals } = useDeleteGoals();
+  const { mutate: deleteGoals } = useDeleteGoals({
+    onSuccess: () => {
+      alert(`Goal 삭제 완료`);
+    },
+  });
 
   return (
     <div className="h-full w-fit space-y-2 bg-white p-4">

--- a/src/app/(routers)/(todo)/goals/types.ts
+++ b/src/app/(routers)/(todo)/goals/types.ts
@@ -1,14 +1,22 @@
+import type { TodoWithFavorites } from '@/api/todos';
+
+export interface TotalListTabProps {
+  goalId: number;
+}
+
 export interface TodoListProps {
+  goalId: number;
   id: number;
-  content: string;
   done: boolean;
-  link: string | null;
+  title: string;
   noteIds: number[];
+  linkUrl: string | null;
   favorites: boolean;
 }
 export interface TodoSectionProps {
+  goalId: number;
   title: string;
-  todos: TodoListProps[];
+  todos: TodoWithFavorites[];
   bgColor: string;
   emptyImage: string;
   emptyText: string;


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #[이슈 번호] <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
**페이지 구성**
- `goals/[goalId]` 상세 페이지 구현
- 목표 진행도 (DonutProgress), 노트 모아보기 링크 카드 추가
- TO DO / DONE 섹션 분리하여 Todo 목록 렌더링

**데이터 패칭**
- `useGetGoal` — 목표 상세 조회 (todos 포함)
- `useGetTodos` — goalId, done, limit, cursor 쿼리 파라미터 지원
- `useGetTodos` 내부에서 `Promise.all`로 todos + favorites 병렬 조회 후 `isFavorite` 필드 병합하여 반환

**목표 수정 / 삭제**
- `usePatchGoals` — 수정 성공 시 `[GOAL, id]`, `[GOALS]` 쿼리 동시 invalidate → 상세 화면 즉시 반영
- `useDeleteGoals` — 삭제 성공 시 `/dashboard`로 리다이렉트
- 
**액션바 (ItemActionBar)**
- 링크 아이콘 클릭 시 `navigator.clipboard`로 URL 복사
- 찜 아이콘 클릭 시 `usePostFavorite` / `useDeleteFavorite` 호출, 성공 시 `[TODOS]` 쿼리 invalidate

**로딩 / 스켈레톤**
- `GoalsInnerTabSkeleton` — 목표 헤더, 진행도, 노트 카드 영역 skeleton
- `TodoSectionSkeleton` — TO DO / DONE 각각 5행 skeleton (showActions 여부에 따라 버튼 skeleton 포함)

**타입 정의**
- `PaginatedResponse<T, K extends string>` — 키 이름을 제네릭으로 받아 `todos` / `favorites` 등 공용 사용
- `TodoWithFavorite = Todo & { isFavorite: boolean }`
- `TodosWithFavoriteResponse = PaginatedResponse<TodoWithFavorite>`

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅
**favorites 병합을 프론트에서 처리한 이유**
현재 백엔드 API가 todos 조회 응답에 `isFavorite` 필드를 포함하지 않고, favorites도 전체 목록만 제공합니다.
`Promise.all`로 병렬 요청 후 `Set<todoId>`로 O(1) 매칭하여 성능 영향을 최소화했습니다.
추후 백엔드 개선 시 todos 응답에 `isFavorite`이 포함되면 favorites 별도 요청은 제거할 예정입니다.
✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅
**`usePatchGoals` invalidate 키 수정**
기존 `[GOALS, GOAL]`로 잘못 지정되어 상세 캐시가 갱신되지 않는 문제가 있었습니다.
`[GOAL, payload.id]`로 수정하여 수정 즉시 화면에 반영되도록 했습니다.


<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](
<img width="725" height="1143" alt="Screenshot 2026-03-26 at 2 04 11 PM" src="https://github.com/user-attachments/assets/4e290c17-65bf-4975-bee3-f28469ea58aa" />
) |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](
<img width="732" height="1099" alt="Screenshot 2026-03-26 at 2 04 18 PM" src="https://github.com/user-attachments/assets/ae5326f7-d132-4005-95cf-a8a93998e804" />
) |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. ...
2. ...
3. ...
```

**예상 결과:**

- ...

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 목표 내부 탭으로 통합된 목표 상세 UI 추가(진행도 도넛, 노트 모아보기 링크)
  * 할 일 목록에 즐겨찾기 상태 병합 표시 및 링크 복사 버튼 추가
  * 할 일 조회에 필터·페이지네이션 지원 추가

* **개선 사항**
  * 편집/삭제 흐름 개선(삭제 시 성공 알림 제공)
  * 로딩 시 스켈레톤 UI 도입으로 체감 성능 향상
  * 관련 데이터 변경 시 목록과 개별 항목 캐시를 즉시 갱신하여 최신성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->