### PR TITLE
Feat/77 post detail comments api

### DIFF
--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -36,10 +36,12 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
     refetch: refetchComments,
   } = useGetComments(postId);
   const { data: user } = useGetUser();
-  const { mutate: deletePost } = useDeletePost();
+  const { mutate: deletePost, isPending: isPostDeleting } = useDeletePost();
   const isWriter = user?.id === post?.userId;
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isCommentBusy, setIsCommentBusy] = useState(false);
+  const isBusy = isCommentBusy || isPostDeleting;
   const [contentReady, setContentReady] = useState(false);
   const router = useRouter();
 
@@ -106,7 +108,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
             <div className="w-full">
               <div className="flex items-start justify-between gap-2">
                 <h1 className="font-base-semibold md:font-xl-semibold text-gray-800">{title}</h1>
-                {isWriter && <KebabMenu items={kebabItems} />}
+                {isWriter && <KebabMenu items={kebabItems} disabled={isBusy} />}
               </div>
 
               <div className="mt-6 flex items-center gap-1">
@@ -128,7 +130,13 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
               </div>
             </div>
 
-            <CommentSection postId={postId} comments={comments} userId={user?.id} />
+            <CommentSection
+              postId={postId}
+              comments={comments}
+              userId={user?.id}
+              isBusy={isBusy}
+              onPendingChange={setIsCommentBusy}
+            />
           </div>
         </div>
       </div>

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -29,7 +29,12 @@ interface PostDetailClientProps {
 
 export function PostDetailClient({ postId }: PostDetailClientProps) {
   const { data: post, isLoading: isPostLoading, isError, refetch } = useGetPostById(postId);
-  const { data: comments, isLoading: isCommentLoading } = useGetComments(postId);
+  const {
+    data: comments,
+    isLoading: isCommentsLoading,
+    isError: isCommentsError,
+    refetch: refetchComments,
+  } = useGetComments(postId);
   const { data: user } = useGetUser();
   const { mutate: deletePost } = useDeletePost();
   const isWriter = user?.id === post?.userId;
@@ -61,12 +66,20 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
     }
   }, [editor, post]);
 
-  if (isError) return <PostErrorFallback onRetry={refetch} />;
-  if (isPostLoading || isCommentLoading) return <PostDetailSkeleton />;
+  if (isError || isCommentsError)
+    return (
+      <PostErrorFallback
+        onRetry={() => {
+          void refetch();
+          void refetchComments();
+        }}
+      />
+    );
+  if (isPostLoading || isCommentsLoading) return <PostDetailSkeleton />;
   if (!post) return <PostErrorFallback onRetry={refetch} />;
   if (!contentReady) return <PostDetailSkeleton />;
 
-  const { title, viewCount, createdAt, writer, commentCount } = post;
+  const { title, viewCount, createdAt, writer } = post;
 
   const kebabItems = [
     { label: '수정하기', onClick: () => router.push(`/community/${postId}/edit`) },
@@ -115,12 +128,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
               </div>
             </div>
 
-            <CommentSection
-              postId={postId}
-              comments={comments?.comments ?? []}
-              userId={user?.id}
-              commentCount={commentCount}
-            />
+            <CommentSection postId={postId} comments={comments} userId={user?.id} />
           </div>
         </div>
       </div>

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -11,7 +11,12 @@ import StarterKit from '@tiptap/starter-kit';
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
 
-import { useDeletePost, useGetPostById, useGetUser } from '../_api/communityQueries';
+import {
+  useDeletePost,
+  useGetComments,
+  useGetPostById,
+  useGetUser,
+} from '../_api/communityQueries';
 import { PostErrorFallback } from '../_components/PostErrorFallback';
 import { WriterAvatar } from '../_components/WriterAvatar';
 import { formatDate } from '../_utils/formatDate';
@@ -23,7 +28,8 @@ interface PostDetailClientProps {
 }
 
 export function PostDetailClient({ postId }: PostDetailClientProps) {
-  const { data: post, isLoading, isError, refetch } = useGetPostById(postId);
+  const { data: post, isLoading: isPostLoading, isError, refetch } = useGetPostById(postId);
+  const { data: comments, isLoading: isCommentLoading } = useGetComments(postId);
   const { data: user } = useGetUser();
   const { mutate: deletePost } = useDeletePost();
   const isWriter = user?.id === post?.userId;
@@ -56,7 +62,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
   }, [editor, post]);
 
   if (isError) return <PostErrorFallback onRetry={refetch} />;
-  if (isLoading) return <PostDetailSkeleton />;
+  if (isPostLoading || isCommentLoading) return <PostDetailSkeleton />;
   if (!post) return <PostErrorFallback onRetry={refetch} />;
   if (!contentReady) return <PostDetailSkeleton />;
 
@@ -108,7 +114,11 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
               </div>
             </div>
 
-            <CommentSection postId={postId} commentCount={commentCount} />
+            <CommentSection
+              comments={comments?.comments ?? []}
+              userId={user?.id}
+              commentCount={commentCount}
+            />
           </div>
         </div>
       </div>

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -83,6 +83,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
         onConfirm={() => {
           deletePost(postId, {
             onSuccess: () => router.push('/community'),
+            onError: () => alert('게시물 삭제에 실패했습니다. 다시 시도해주세요.'),
           });
         }}
       />
@@ -115,6 +116,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
             </div>
 
             <CommentSection
+              postId={postId}
               comments={comments?.comments ?? []}
               userId={user?.id}
               commentCount={commentCount}

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -68,7 +68,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
     }
   }, [editor, post]);
 
-  if (isError || isCommentsError)
+  if ((isError && !post) || (isCommentsError && !comments))
     return (
       <PostErrorFallback
         onRetry={() => {

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -7,15 +7,16 @@ import { useState } from 'react';
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
 
-import { formatRelativeTime } from '../../_utils/formatRelativeTime';
 import { WriterAvatar } from '../../_components/WriterAvatar';
+import { formatRelativeTime } from '../../_utils/formatRelativeTime';
 
 interface CommentItemProps {
   comment: Comment;
+  isMyComment: boolean;
 }
 
-export function CommentItem({ comment }: CommentItemProps) {
-  const { content, createdAt, writer, isMyComment } = comment;
+export function CommentItem({ comment, isMyComment }: CommentItemProps) {
+  const { content, createdAt, writer } = comment;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const kebabItems = [
@@ -34,25 +35,25 @@ export function CommentItem({ comment }: CommentItemProps) {
           // TODO: 댓글 삭제 API 연동
         }}
       />
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <WriterAvatar name={writer.name} image={writer.image} />
-            <span className="font-xs-regular md:font-sm-regular text-gray-500">{writer.name}</span>
-            {isMyComment && (
-              <span className="font-xs-medium rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-amber-700">
-                내 댓글
-              </span>
-            )}
-          </div>
-          {isMyComment && <KebabMenu items={kebabItems} />}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <WriterAvatar name={writer.name} image={writer.image} />
+          <span className="font-xs-regular md:font-sm-regular text-gray-500">{writer.name}</span>
+          {isMyComment && (
+            <span className="font-xs-medium rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-amber-700">
+              내 댓글
+            </span>
+          )}
         </div>
+        {isMyComment && <KebabMenu items={kebabItems} />}
+      </div>
 
-        <div className="flex flex-col gap-2">
-          <p className="font-sm-regular md:font-base-regular text-gray-700">{content}</p>
-          <span className="font-xs-regular md:font-sm-regular text-gray-400">
-            {formatRelativeTime(createdAt)}
-          </span>
-        </div>
+      <div className="flex flex-col gap-2">
+        <p className="font-sm-regular md:font-base-regular text-gray-700">{content}</p>
+        <span className="font-xs-regular md:font-sm-regular text-gray-400">
+          {formatRelativeTime(createdAt)}
+        </span>
+      </div>
     </li>
   );
 }

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
 
+import { useDeleteComment } from '../../_api/communityQueries';
 import { WriterAvatar } from '../../_components/WriterAvatar';
 import { formatRelativeTime } from '../../_utils/formatRelativeTime';
 
@@ -18,6 +19,7 @@ interface CommentItemProps {
 export function CommentItem({ comment, isMyComment }: CommentItemProps) {
   const { content, createdAt, writer } = comment;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const { mutate: deleteComment } = useDeleteComment(comment.postId);
 
   const kebabItems = [
     { label: '수정하기', onClick: () => {} /* TODO: 댓글 수정 API 연동 */ },
@@ -32,7 +34,7 @@ export function CommentItem({ comment, isMyComment }: CommentItemProps) {
         title="정말 삭제하시겠어요?"
         description="삭제된 댓글은 복구할 수 없습니다."
         onConfirm={() => {
-          // TODO: 댓글 삭제 API 연동
+          deleteComment(comment.id);
         }}
       />
       <div className="flex items-center justify-between">

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -7,19 +7,19 @@ import { useState } from 'react';
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
 
-import { useDeleteComment } from '../../_api/communityQueries';
 import { WriterAvatar } from '../../_components/WriterAvatar';
 import { formatRelativeTime } from '../../_utils/formatRelativeTime';
 
 interface CommentItemProps {
   comment: Comment;
   isMyComment: boolean;
+  onDelete: (commentId: number, options?: { onError?: () => void }) => void;
+  isDeleting: boolean;
 }
 
-export function CommentItem({ comment, isMyComment }: CommentItemProps) {
+export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: CommentItemProps) {
   const { content, createdAt, writer } = comment;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const { mutate: deleteComment } = useDeleteComment(comment.postId);
 
   const kebabItems = [
     { label: '수정하기', onClick: () => {} /* TODO: 댓글 수정 API 연동 */ },
@@ -34,7 +34,7 @@ export function CommentItem({ comment, isMyComment }: CommentItemProps) {
         title="정말 삭제하시겠어요?"
         description="삭제된 댓글은 복구할 수 없습니다."
         onConfirm={() => {
-          deleteComment(comment.id, {
+          onDelete(comment.id, {
             onError: () => alert('댓글 삭제에 실패했습니다. 다시 시도해주세요.'),
           });
         }}
@@ -49,7 +49,7 @@ export function CommentItem({ comment, isMyComment }: CommentItemProps) {
             </span>
           )}
         </div>
-        {isMyComment && <KebabMenu items={kebabItems} />}
+        {isMyComment && <KebabMenu items={kebabItems} disabled={isDeleting} />}
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -34,7 +34,9 @@ export function CommentItem({ comment, isMyComment }: CommentItemProps) {
         title="정말 삭제하시겠어요?"
         description="삭제된 댓글은 복구할 수 없습니다."
         onConfirm={() => {
-          deleteComment(comment.id);
+          deleteComment(comment.id, {
+            onError: () => alert('댓글 삭제에 실패했습니다. 다시 시도해주세요.'),
+          });
         }}
       />
       <div className="flex items-center justify-between">

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -1,22 +1,19 @@
 'use client';
 
+import type { Comment } from '../../types';
+
 import { useState } from 'react';
 
-import { useGetComments } from '../../_api/communityQueries';
 import { CommentItem } from './CommentItem';
 
 interface CommentSectionProps {
-  postId: number;
+  comments: Comment[];
+  userId: number | undefined;
   commentCount: number;
 }
 
-export function CommentSection({ postId, commentCount }: CommentSectionProps) {
-  const { data } = useGetComments(postId);
+export function CommentSection({ comments, userId, commentCount }: CommentSectionProps) {
   const [inputValue, setInputValue] = useState('');
-  // TODO: Auth 개발 후 현재 로그인한 유저의 ID를 가져와야 함
-  const currentUserId = 1;
-
-  const comments = data?.comments ?? [];
 
   const handleSubmit = () => {
     if (!inputValue.trim()) return;
@@ -60,11 +57,7 @@ export function CommentSection({ postId, commentCount }: CommentSectionProps) {
 
       <ul className="flex flex-col gap-8 md:gap-10">
         {comments.map((comment) => (
-          <CommentItem
-            key={comment.id}
-            comment={comment}
-            isMyComment={comment.userId === currentUserId}
-          />
+          <CommentItem key={comment.id} comment={comment} isMyComment={comment.userId === userId} />
         ))}
       </ul>
     </div>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -4,20 +4,26 @@ import type { Comment } from '../../types';
 
 import { useState } from 'react';
 
+import { useCreateComment } from '../../_api/communityQueries';
 import { CommentItem } from './CommentItem';
 
 interface CommentSectionProps {
+  postId: number;
   comments: Comment[];
   userId: number | undefined;
   commentCount: number;
 }
 
-export function CommentSection({ comments, userId, commentCount }: CommentSectionProps) {
+export function CommentSection({ postId, comments, userId, commentCount }: CommentSectionProps) {
   const [inputValue, setInputValue] = useState('');
+  const { mutate: createComment } = useCreateComment(postId);
 
   const handleSubmit = () => {
     if (!inputValue.trim()) return;
-    setInputValue('');
+    createComment(inputValue, {
+      onSuccess: () => setInputValue(''),
+      onError: () => alert('댓글 등록에 실패했습니다. 다시 시도해주세요.'),
+    });
   };
 
   return (

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -1,47 +1,25 @@
 'use client';
 
-import type { Comment } from '../../types';
-
 import { useState } from 'react';
 
+import { useGetComments } from '../../_api/communityQueries';
 import { CommentItem } from './CommentItem';
-
-const MOCK_COMMENTS: Comment[] = [
-  {
-    id: 1,
-    content: '저도 아이젠하워 매트릭스 활용하고 있어요! 확실히 우선순위 정하기 편하더라고요.',
-    createdAt: '2025-05-22T01:00:00.000Z',
-    writer: { id: 2, name: '고길동', image: null },
-    isMyComment: false,
-  },
-  {
-    id: 2,
-    content: '저는 그냥 중요한 것부터 하는 편인데, 매트릭스 한번 써봐야겠네요!',
-    createdAt: '2025-05-22T02:00:00.000Z',
-    writer: { id: 1, name: '체다치즈', image: null },
-    isMyComment: true,
-  },
-  {
-    id: 3,
-    content: 'GTD 방식도 추천드려요. 일단 모든 할 일을 적고 나서 분류하면 머릿속이 훨씬 정리돼요.',
-    createdAt: '2025-05-22T03:00:00.000Z',
-    writer: { id: 3, name: '홍길동', image: null },
-    isMyComment: false,
-  },
-];
 
 interface CommentSectionProps {
   postId: number;
   commentCount: number;
 }
 
-// TODO: 댓글 API 연동 시 postId 사용
-export function CommentSection({ postId: _postId, commentCount }: CommentSectionProps) {
+export function CommentSection({ postId, commentCount }: CommentSectionProps) {
+  const { data } = useGetComments(postId);
   const [inputValue, setInputValue] = useState('');
+  // TODO: Auth 개발 후 현재 로그인한 유저의 ID를 가져와야 함
+  const currentUserId = 1;
+
+  const comments = data?.comments ?? [];
 
   const handleSubmit = () => {
     if (!inputValue.trim()) return;
-    // TODO: 댓글 등록 API 연동
     setInputValue('');
   };
 
@@ -81,8 +59,12 @@ export function CommentSection({ postId: _postId, commentCount }: CommentSection
       </div>
 
       <ul className="flex flex-col gap-8 md:gap-10">
-        {MOCK_COMMENTS.map((comment) => (
-          <CommentItem key={comment.id} comment={comment} />
+        {comments.map((comment) => (
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            isMyComment={comment.userId === currentUserId}
+          />
         ))}
       </ul>
     </div>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -2,22 +2,35 @@
 
 import type { CommentsResponse } from '../../types';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { useCreateComment } from '../../_api/communityQueries';
+import { useCreateComment, useDeleteComment } from '../../_api/communityQueries';
 import { CommentItem } from './CommentItem';
 
 interface CommentSectionProps {
   postId: number;
   comments: CommentsResponse | undefined;
   userId: number | undefined;
+  isBusy?: boolean;
+  onPendingChange?: (isPending: boolean) => void;
 }
 
-export function CommentSection({ postId, comments, userId }: CommentSectionProps) {
+export function CommentSection({
+  postId,
+  comments,
+  userId,
+  isBusy = false,
+  onPendingChange,
+}: CommentSectionProps) {
   const commentList = comments?.comments ?? [];
   const totalCount = comments?.totalCount ?? 0;
   const [inputValue, setInputValue] = useState('');
   const { mutate: createComment, isPending: isCreating } = useCreateComment(postId);
+  const { mutate: deleteComment, isPending: isDeleting } = useDeleteComment(postId);
+
+  useEffect(() => {
+    onPendingChange?.(isCreating || isDeleting);
+  }, [isCreating, isDeleting, onPendingChange]);
 
   const handleSubmit = () => {
     if (!inputValue.trim() || isCreating) return;
@@ -46,14 +59,15 @@ export function CommentSection({ postId, comments, userId }: CommentSectionProps
               handleSubmit();
             }
           }}
+          disabled={isBusy}
           placeholder="댓글을 입력해주세요"
           aria-label="댓글 입력"
-          className="font-sm-regular md:font-base-regular flex-1 rounded-xl border border-gray-300 px-3 py-3 text-gray-700 outline-none placeholder:text-gray-500 md:rounded-2xl md:px-4 md:py-4"
+          className="font-sm-regular md:font-base-regular flex-1 rounded-xl border border-gray-300 px-3 py-3 text-gray-700 outline-none placeholder:text-gray-500 disabled:bg-gray-50 md:rounded-2xl md:px-4 md:py-4"
         />
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={!inputValue.trim() || isCreating}
+          disabled={!inputValue.trim() || isBusy}
           className="font-sm-semibold md:font-base-semibold w-16 shrink-0 rounded-full bg-orange-500 py-2.5 text-white disabled:cursor-not-allowed disabled:bg-gray-300 md:w-20 md:py-3"
         >
           등록
@@ -62,7 +76,13 @@ export function CommentSection({ postId, comments, userId }: CommentSectionProps
 
       <ul className="flex flex-col gap-8 md:gap-10">
         {commentList.map((comment) => (
-          <CommentItem key={comment.id} comment={comment} isMyComment={comment.userId === userId} />
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            isMyComment={comment.userId === userId}
+            onDelete={deleteComment}
+            isDeleting={isBusy}
+          />
         ))}
       </ul>
     </div>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Comment } from '../../types';
+import type { CommentsResponse } from '../../types';
 
 import { useState } from 'react';
 
@@ -9,17 +9,18 @@ import { CommentItem } from './CommentItem';
 
 interface CommentSectionProps {
   postId: number;
-  comments: Comment[];
+  comments: CommentsResponse | undefined;
   userId: number | undefined;
-  commentCount: number;
 }
 
-export function CommentSection({ postId, comments, userId, commentCount }: CommentSectionProps) {
+export function CommentSection({ postId, comments, userId }: CommentSectionProps) {
+  const commentList = comments?.comments ?? [];
+  const totalCount = comments?.totalCount ?? 0;
   const [inputValue, setInputValue] = useState('');
-  const { mutate: createComment } = useCreateComment(postId);
+  const { mutate: createComment, isPending: isCreating } = useCreateComment(postId);
 
   const handleSubmit = () => {
-    if (!inputValue.trim()) return;
+    if (!inputValue.trim() || isCreating) return;
     createComment(inputValue, {
       onSuccess: () => setInputValue(''),
       onError: () => alert('댓글 등록에 실패했습니다. 다시 시도해주세요.'),
@@ -30,9 +31,7 @@ export function CommentSection({ postId, comments, userId, commentCount }: Comme
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-0.5">
         <span className="font-base-semibold md:font-lg-semibold text-gray-800">댓글</span>
-        <span className="font-base-semibold md:font-lg-semibold text-orange-600">
-          {commentCount}
-        </span>
+        <span className="font-base-semibold md:font-lg-semibold text-orange-600">{totalCount}</span>
       </div>
 
       <div className="flex gap-3 md:gap-4">
@@ -54,7 +53,7 @@ export function CommentSection({ postId, comments, userId, commentCount }: Comme
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={!inputValue.trim()}
+          disabled={!inputValue.trim() || isCreating}
           className="font-sm-semibold md:font-base-semibold w-16 shrink-0 rounded-full bg-orange-500 py-2.5 text-white disabled:cursor-not-allowed disabled:bg-gray-300 md:w-20 md:py-3"
         >
           등록
@@ -62,7 +61,7 @@ export function CommentSection({ postId, comments, userId, commentCount }: Comme
       </div>
 
       <ul className="flex flex-col gap-8 md:gap-10">
-        {comments.map((comment) => (
+        {commentList.map((comment) => (
           <CommentItem key={comment.id} comment={comment} isMyComment={comment.userId === userId} />
         ))}
       </ul>

--- a/src/app/(routers)/(board)/community/[id]/_components/PostDetailSkeleton.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/PostDetailSkeleton.tsx
@@ -25,6 +25,30 @@ export function PostDetailSkeleton() {
 
             <div className="mt-4 h-3 w-32 animate-pulse rounded-md bg-gray-200" />
           </div>
+
+          <div className="flex flex-col gap-6">
+            <div className="h-5 w-16 animate-pulse rounded-md bg-gray-200" />
+
+            <div className="flex gap-3 md:gap-4">
+              <div className="h-12 flex-1 animate-pulse rounded-xl bg-gray-200 md:h-14 md:rounded-2xl" />
+              <div className="h-12 w-16 animate-pulse rounded-full bg-gray-200 md:h-14 md:w-20" />
+            </div>
+
+            <ul className="flex flex-col gap-8 md:gap-10">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li key={i} className="flex flex-col gap-3">
+                  <div className="flex items-center gap-3">
+                    <div className="size-8 animate-pulse rounded-full bg-gray-200" />
+                    <div className="h-4 w-20 animate-pulse rounded-md bg-gray-200" />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <div className="h-4 w-full animate-pulse rounded-md bg-gray-200" />
+                    <div className="h-3 w-16 animate-pulse rounded-md bg-gray-200" />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -1,9 +1,15 @@
-import type { Post, PostsResponse, SortOption, UpdatePostInput, User } from '../types';
+import type { Comment, Post, PostsResponse, SortOption, UpdatePostInput, User } from '../types';
 
 import { apiClient } from '@/lib/apiClient';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { communityQueryKeys } from './communityQueryKeys';
+
+export interface CommentsResponse {
+  comments: Comment[];
+  nextCursor: string | null;
+  totalCount: number;
+}
 
 const toApiType = (sort: SortOption): 'all' | 'best' => (sort === '인기순' ? 'best' : 'all');
 
@@ -15,7 +21,7 @@ export const useGetUser = () => {
   });
 };
 
-// 게시물 전체 조회
+// 게시물 목록 조회
 export const useGetPosts = (sort: SortOption = '최신순') => {
   const type = toApiType(sort);
   return useQuery({
@@ -67,5 +73,15 @@ export const useDeletePost = () => {
       queryClient.removeQueries({ queryKey: communityQueryKeys.post(deletedPostId) });
       queryClient.invalidateQueries({ queryKey: [...communityQueryKeys.all, 'posts'] });
     },
+  });
+};
+
+// 댓글 목록 조회
+export const useGetComments = (postId: number) => {
+  return useQuery({
+    queryKey: communityQueryKeys.comments(postId),
+    queryFn: () => apiClient<CommentsResponse>(`/posts/${postId}/comments`),
+    staleTime: 1000 * 60 * 5,
+    enabled: Number.isInteger(postId) && postId > 0,
   });
 };

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -51,6 +51,7 @@ export const useUpdatePost = (postId: number) => {
     mutationFn: (updatePost: UpdatePostInput) =>
       apiClient<Post>(`/posts/${postId}`, {
         method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updatePost),
       }),
     onSuccess: () => {
@@ -59,7 +60,7 @@ export const useUpdatePost = (postId: number) => {
     },
   });
 
-  return { ...mutation, postId };
+  return { ...mutation };
 };
 
 // 게시물 삭제

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -1,15 +1,16 @@
-import type { Comment, Post, PostsResponse, SortOption, UpdatePostInput, User } from '../types';
+import type {
+  CommentsResponse,
+  Post,
+  PostsResponse,
+  SortOption,
+  UpdatePostInput,
+  User,
+} from '../types';
 
 import { apiClient } from '@/lib/apiClient';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { communityQueryKeys } from './communityQueryKeys';
-
-export interface CommentsResponse {
-  comments: Comment[];
-  nextCursor: string | null;
-  totalCount: number;
-}
 
 const toApiType = (sort: SortOption): 'all' | 'best' => (sort === '인기순' ? 'best' : 'all');
 
@@ -83,5 +84,20 @@ export const useGetComments = (postId: number) => {
     queryFn: () => apiClient<CommentsResponse>(`/posts/${postId}/comments`),
     staleTime: 1000 * 60 * 5,
     enabled: Number.isInteger(postId) && postId > 0,
+  });
+};
+
+// 댓글 삭제
+export const useDeleteComment = (postId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: number) =>
+      apiClient<void>(`/posts/${postId}/comments/${commentId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communityQueryKeys.comments(postId) });
+    },
   });
 };

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -1,4 +1,5 @@
 import type {
+  Comment,
   CommentsResponse,
   Post,
   PostsResponse,
@@ -77,6 +78,24 @@ export const useDeletePost = () => {
   });
 };
 
+// 댓글 등록
+export const useCreateComment = (postId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (content: string) =>
+      apiClient<Comment>(`/posts/${postId}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communityQueryKeys.post(postId) });
+      queryClient.invalidateQueries({ queryKey: communityQueryKeys.comments(postId) });
+    },
+  });
+};
+
 // 댓글 목록 조회
 export const useGetComments = (postId: number) => {
   return useQuery({
@@ -97,6 +116,7 @@ export const useDeleteComment = (postId: number) => {
         method: 'DELETE',
       }),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communityQueryKeys.post(postId) });
       queryClient.invalidateQueries({ queryKey: communityQueryKeys.comments(postId) });
     },
   });

--- a/src/app/(routers)/(board)/community/_api/communityQueryKeys.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueryKeys.ts
@@ -2,4 +2,5 @@ export const communityQueryKeys = {
   all: ['community'] as const,
   posts: (type: 'all' | 'best' = 'all') => [...communityQueryKeys.all, 'posts', type] as const,
   post: (id: number) => [...communityQueryKeys.all, 'post', id] as const,
+  comments: (postId: number) => [...communityQueryKeys.all, 'comments', postId] as const,
 } as const;

--- a/src/app/(routers)/(board)/community/types.ts
+++ b/src/app/(routers)/(board)/community/types.ts
@@ -50,3 +50,9 @@ export interface User {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface CommentsResponse {
+  comments: Comment[];
+  nextCursor: string | null;
+  totalCount: number;
+}

--- a/src/app/(routers)/(board)/community/types.ts
+++ b/src/app/(routers)/(board)/community/types.ts
@@ -8,10 +8,12 @@ export interface Writer {
 
 export interface Comment {
   id: number;
+  userId: number;
+  postId: number;
   content: string;
   createdAt: string;
+  updatedAt: string;
   writer: Writer;
-  isMyComment: boolean;
 }
 
 export interface Post {

--- a/src/components/common/KebabMenu.tsx
+++ b/src/components/common/KebabMenu.tsx
@@ -12,9 +12,10 @@ export interface KebabMenuItem {
 
 interface KebabMenuProps {
   items: KebabMenuItem[];
+  disabled?: boolean;
 }
 
-export function KebabMenu({ items }: KebabMenuProps) {
+export function KebabMenu({ items, disabled = false }: KebabMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const menuId = useId();
@@ -41,7 +42,8 @@ export function KebabMenu({ items }: KebabMenuProps) {
         aria-expanded={isOpen}
         aria-controls={menuId}
         aria-label="더보기"
-        className="flex cursor-pointer items-center justify-center rounded-lg p-1 hover:bg-gray-100"
+        disabled={disabled}
+        className="flex cursor-pointer items-center justify-center rounded-lg p-1 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
       >
         <Icon name="more" size={24} />
       </button>


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #77  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 댓글 목록 조회 / 작성 / 삭제 API 연동 (useGetComments, useCreateComment, useDeleteComment)
- 게시물과 댓글을 동시에 fetch하도록 개선 → 로딩 상태 단일화
- 댓글 작성자 본인 여부(isMyComment)를 CommentSection에서 계산 후 CommentItem에 prop으로 전달
- PostDetailSkeleton에 댓글 입력창 및 댓글 목록 스켈레톤 추가
- 댓글 등록/삭제 성공 시 commentCount도 함께 갱신되도록 post 쿼리 invalidate 추가
- 댓글/게시물 뮤테이션 진행 중 상세 페이지 전체 인터랙션 비활성화 (isBusy)
- 댓글 작성/삭제 중 → 게시물 케밥, 댓글 입력/등록/케밥 비활성화
- 게시물 삭제 중 → 동일하게 전체 비활성화
- KebabMenu 공통 컴포넌트에 disabled prop 추가

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 기존에는 CommentSection이 마운트된 후 댓글 fetch가 시작되어 게시물 → 댓글 순서로 순차 로딩됐습니다. 
- useGetComments를 PostDetailClient로 올려 두 쿼리를 동시에 시작해 로딩 상태를 하나로 통일했습니다.
- isMyComment는 API 응답에 없는 값이므로 comment.userId === userId 비교로 클라이언트에서 직접 계산했습니다.

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

<img width="911" height="755" alt="스크린샷 2026-03-25 오후 2 09 39" src="https://github.com/user-attachments/assets/d1dbf636-47ee-416e-8125-19eb0ae0a344" />


---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 소통 게시판에서 게시물 상세 페이지 진입
2. 댓글 입력창에 내용 입력 후 등록 버튼 클릭 또는 Enter
3. 댓글이 목록에 추가되고 댓글 수가 증가하는지 확인
4. 본인 댓글에 케밥 메뉴 클릭 → 삭제하기 선택
5. 삭제 확인 다이얼로그에서 확인 클릭
6. 댓글이 목록에서 사라지고 댓글 수가 감소하는지 확인
7. 댓글 등록 버튼 클릭 직후 게시물 케밥 메뉴, 댓글 입력창, 등록 버튼이 비활성화되는지 확인
8. 댓글 삭제 진행 중 다른 댓글의 케밥 메뉴가 비활성화되는지 확인

```

**예상 결과:**
- 페이지 진입 시 게시물과 댓글이 동시에 로딩됨 (스켈레톤 1회 노출)
- 본인 댓글에만 내 댓글 뱃지와 케밥 메뉴 표시
- 등록/삭제 실패 시 alert 노출

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->
- userId는 현재 useGetUser()(/users/me)로 가져오고 있으며, 추후 Auth 공통 훅으로 이전 예정입니다.
- 댓글 수정 API가 스웨거에 없어 수정 기능은 미구현 상태입니다. 케밥 메뉴에 수정하기 항목은 TODO로 남겨두었으며 백엔드 확인 후 구현 예정입니다.
- onPendingChange 콜백으로 CommentSection의 pending 상태를 PostDetailClient로 전달해
게시물 케밥까지 통합 비활성화 처리했습니다.


---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 목록 조회 및 실제 댓글 데이터 기반 댓글 섹션 도입
  * 댓글 작성·삭제 기능 추가 및 댓글 상태 전파(onPendingChange)

* **버그 수정**
  * 댓글/게시물 삭제 실패 시 사용자 알림 표시
  * 포스트·댓글 쿼리의 로딩/오류 상태를 함께 반영하는 에러/스켈레톤 처리

* **개선 사항**
  * 상세 보기 로딩 시 확장된 스켈레톤 UI 적용
  * 작성자 전용 메뉴에 삭제 진행상태에 따른 비활성화 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->