### PR TITLE
:sparkles: feature:note 삭제 API 낙관적 적용

### DIFF
--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -201,9 +201,30 @@ export const useDeleteNote = () => {
     mutationFn: async ({ id }: { id: number }) => {
       return await apiClient(`${NOTES_URL}/${id}`, { method: 'DELETE' });
     },
-    onSuccess: (_, { id }) => {
+    onMutate: async ({ id }: { id: number }) => {
+      await queryClient.cancelQueries({ queryKey: [NOTES] });
+      const previousTodos = queryClient.getQueriesData({ queryKey: [NOTES] });
+      queryClient.setQueriesData(
+        { queryKey: [NOTES] },
+        (old: PaginatedResponse<Notes, 'notes'>) => {
+          if (!old) return old;
+          return {
+            ...old,
+            notes: old.notes.filter((note: Notes) => note.id !== id),
+            totalCount: old.totalCount - 1,
+          };
+        },
+      );
+      return { previousTodos };
+    },
+    onError: (_: Error, __, context) => {
+      context?.previousTodos.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+    onSettled: (_, __, payload) => {
       queryClient.invalidateQueries({ queryKey: [NOTES] });
-      queryClient.removeQueries({ queryKey: [NOTE, id] });
+      queryClient.invalidateQueries({ queryKey: [NOTE, payload.id] });
     },
   });
 };

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteCard.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteCard.tsx
@@ -5,6 +5,7 @@ import type { Todo } from '@/api/todos';
 import Image from 'next/image';
 import Link from 'next/link';
 import imgNote from '@/../public/images/img-note.svg';
+import { useDeleteNote } from '@/api/notes';
 import { cn } from '@/lib';
 
 import { formatDate } from '@/utils/date';
@@ -27,6 +28,7 @@ export default function NoteCard({
   todo: Pick<Todo, 'id' | 'title' | 'done'>;
   createdAt: string;
 }) {
+  const { mutate: deleteNote } = useDeleteNote();
   return (
     <Link
       href={`/goals/${goalId}/notes/${id}`}
@@ -72,7 +74,7 @@ export default function NoteCard({
             title="정말 삭제하시겠어요?"
             description="삭제된 노트는 복구할 수 없습니다."
             onConfirm={() => {
-              console.log('delete');
+              deleteNote({ id });
             }}
           />
         </div>


### PR DESCRIPTION
# 📋 PR 개요

# 📋 PR 개요
노트 삭제 기능 구현 — 낙관적 업데이트를 적용하여 삭제 즉시 UI에 반영되도록 합니다.
- **관련 이슈:** Closes #131 
- **PR 유형:**
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

### What

**NoteCard — 삭제 기능 연결**
- `useDeleteNote` 호출하여 `DeleteDialog`의 `onConfirm`에 연결
- `e.stopPropagation()` / `e.preventDefault()`로 Link 이동 방지 처리

**useDeleteNote — 낙관적 업데이트 적용**
- `onMutate`: 진행 중인 NOTES 쿼리 취소 → 캐시 스냅샷 저장 → 삭제 대상 노트 즉시 제거 및 `totalCount - 1`
- `onError`: 실패 시 스냅샷으로 롤백
- `onSettled`: 성공/실패 무관하게 NOTES, NOTE 캐시 최종 동기화

---

### Why

**낙관적 업데이트를 적용한 이유**

삭제 API 응답을 기다리면 목록에서 카드가 바로 사라지지 않아 UX가 어색합니다.
`onMutate`에서 캐시를 즉시 업데이트하여 삭제 즉시 목록에서 제거되도록 했습니다.
실패 시 `onError`에서 스냅샷으로 롤백하여 데이터 정합성을 보장합니다.

**`totalCount`도 함께 감소시킨 이유**

삭제 후 `totalCount`가 그대로면 페이지네이션이나 카운트를 표시하는 쪽에서 틀린 값을 보여줄 수 있어 함께 처리했습니다.

---

## ✅ 체크리스트

### 코드 품질
- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)
- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [x] 새로운 타입/인터페이스 정의 완료
- [x] `tsc --noEmit` 통과 확인

### 테스트
- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)
- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능
- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)
| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법
```text
1. /goals/:goalId/notes 진입
2. 노트 카드 우측 점 세개 버튼 클릭
3. 삭제 다이얼로그 확인 버튼 클릭
4. API 응답 전 목록에서 즉시 사라지는지 확인
5. 새로고침 후에도 삭제된 노트가 없는지 확인
6. (네트워크 오류 시) 삭제 실패 후 노트가 다시 나타나는지 확인
```

**예상 결과:**
- 삭제 확인 즉시 목록에서 카드 제거 (낙관적 업데이트)
- API 실패 시 카드 복원 (롤백)
- `totalCount` 삭제 수만큼 감소

---

## ⚠️ 리뷰어 참고사항
- 삭제는 되돌릴 수 없는 작업이므로 `DeleteDialog`로 2단계 확인을 거칩니다.
- `onSettled`에서 `removeQueries` 대신 `invalidateQueries`를 사용하여 뒤로가기 시 캐시 미스가 발생하지 않도록 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 노트 삭제 기능이 이제 정상적으로 작동합니다.
* 삭제 확인 시 UI가 즉시 업데이트되도록 개선되었습니다.
* 삭제 작업 실패 시 이전 상태로 자동 복구되는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->