### PR TITLE
:sparkles: feature: calender page ui 생성

### DIFF
--- a/src/app/(routers)/calendar/_components/BottomButton.tsx
+++ b/src/app/(routers)/calendar/_components/BottomButton.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { Icon } from '@/components/icon/Icon';
+import { IconButton } from '@/components/ui/button';
+
+export default function BottomButton() {
+  return (
+    <IconButton variant="outline" className="w-full">
+      <Icon name="plus" variant="orange" />할 일 추가
+    </IconButton>
+  );
+}

--- a/src/app/(routers)/calendar/_components/CalenderGrid.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderGrid.tsx
@@ -17,19 +17,19 @@ interface Cell {
   dayTodos: CalendarTodo[];
 }
 
-interface CalendarGridProps {
+interface CalenderGridProps {
   cells: Cell[];
   totalCells: number;
   selectedDate: string;
   onSelectDate: (date: string) => void;
 }
 
-export default function CalendarGrid({
+export default function CalenderGrid({
   cells,
   totalCells,
   selectedDate,
   onSelectDate,
-}: CalendarGridProps) {
+}: CalenderGridProps) {
   return (
     <div className="flex h-[530px] flex-col lg:h-206">
       <div className="grid h-8 shrink-0 grid-cols-7">

--- a/src/app/(routers)/calendar/_components/CalenderGrid.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderGrid.tsx
@@ -59,6 +59,7 @@ export default function CalendarGrid({
             )}
           >
             <button
+              type="button"
               className="flex h-full w-full flex-col overflow-hidden p-1.5"
               onClick={() => onSelectDate(dateStr)}
             >

--- a/src/app/(routers)/calendar/_components/CalenderGrid.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderGrid.tsx
@@ -1,0 +1,144 @@
+import type { Todo } from '@/api/todos';
+
+import { cn } from '@/lib';
+
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+
+type CalendarTodo = Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>;
+
+interface Cell {
+  day: number;
+  dateStr: string;
+  isOther: boolean;
+  isToday: boolean;
+  dow: number;
+  dayTodos: CalendarTodo[];
+}
+
+interface CalendarGridProps {
+  cells: Cell[];
+  totalCells: number;
+  selectedDate: string;
+  onSelectDate: (date: string) => void;
+}
+
+export default function CalendarGrid({
+  cells,
+  totalCells,
+  selectedDate,
+  onSelectDate,
+}: CalendarGridProps) {
+  return (
+    <div className="flex h-[530px] flex-col lg:h-206">
+      <div className="grid h-8 shrink-0 grid-cols-7">
+        {DAY_LABELS.map((label, i) => (
+          <div
+            key={label}
+            className={cn(
+              'font-xs-medium border border-gray-100 py-2 text-center text-xs',
+              i === 0 ? 'text-orange-500' : 'text-gray-500',
+            )}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+      <div
+        className="grid flex-1 grid-cols-7"
+        style={{ gridTemplateRows: `repeat(${totalCells / 7}, 1fr)` }}
+      >
+        {cells.map(({ day, dateStr, isOther, isToday, dow, dayTodos }, i) => (
+          <div
+            key={dateStr + i}
+            className={cn(
+              'overflow-hidden border-t border-r border-gray-100',
+              '[&:nth-child(7n)]:border-r-0',
+              isOther && 'bg-gray-50/50',
+            )}
+          >
+            <button
+              className="flex h-full w-full flex-col overflow-hidden p-1.5"
+              onClick={() => onSelectDate(dateStr)}
+            >
+              <span
+                className={cn(
+                  'font-xs-semibold mb-1 inline-flex h-6 w-6 items-center justify-center',
+                  !isToday && !isOther && dow === 0 && 'text-orange-500',
+                  !isToday && !isOther && dow === 6 && 'text-gray-500',
+                  !isToday && !isOther && dow !== 0 && dow !== 6 && 'text-gray-600',
+                  isToday && selectedDate !== dateStr && 'rounded-full bg-gray-200 text-gray-700',
+                  selectedDate === dateStr && 'rounded-full bg-orange-500 text-white',
+                )}
+              >
+                {day}
+              </span>
+              {/* mobile - dot */}
+              <div className="flex flex-col items-start space-y-1 lg:hidden">
+                <div className="flex space-x-1">
+                  {dayTodos.slice(0, 3).map((todo) => (
+                    <div
+                      key={todo.id}
+                      className={cn(
+                        'size-2 rounded-[4px]',
+                        todo.done ? 'bg-gray-400' : 'bg-orange-500',
+                      )}
+                    />
+                  ))}
+                </div>
+                {dayTodos.length > 3 && (
+                  <span className="font-xs-semibold text-gray-400">+{dayTodos.length - 3}개</span>
+                )}
+              </div>
+              {/* desktop - 할일 목록 */}
+              <div className="hidden flex-col space-y-1 text-left lg:flex">
+                {dayTodos.slice(0, 3).map((todo) => (
+                  <div
+                    key={todo.id}
+                    className={cn(
+                      'font-xs-semibold truncate rounded-[6px] border px-2 py-1 text-left',
+                      todo.done
+                        ? 'border-gray-300 bg-gray-50 text-gray-400'
+                        : 'border-orange-300 bg-orange-100 text-orange-600',
+                    )}
+                  >
+                    {todo.done ? '✓ ' : ''}
+                    {todo.title}
+                  </div>
+                ))}
+                {dayTodos.length > 3 && (
+                  <HoverCard>
+                    <HoverCardTrigger>
+                      <span className="font-xs-semibold cursor-pointer px-1 text-left text-gray-400 hover:text-gray-600">
+                        +{dayTodos.length - 3}개
+                      </span>
+                    </HoverCardTrigger>
+                    <HoverCardContent className="w-60 p-2">
+                      <div className="flex flex-col space-y-1">
+                        {dayTodos.slice(3).map((todo) => (
+                          <div
+                            key={todo.id}
+                            className={cn(
+                              'font-xs-semibold truncate rounded-[6px] border px-2 py-1',
+                              todo.done
+                                ? 'border-gray-300 bg-gray-50 text-gray-400'
+                                : 'border-orange-300 bg-orange-100 text-orange-600',
+                            )}
+                          >
+                            {todo.done ? '✓ ' : ''}
+                            {todo.title}
+                          </div>
+                        ))}
+                      </div>
+                    </HoverCardContent>
+                  </HoverCard>
+                )}
+              </div>
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(routers)/calendar/_components/CalenderHead.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderHead.tsx
@@ -12,7 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-interface CalendarHeaderProps {
+interface CalenderHeadProps {
   y: number;
   m: number;
   prevYear: () => void;
@@ -28,7 +28,7 @@ const selectValue = [
   { label: '디자인 시스템 정복하기', value: 2 },
 ];
 
-export default function CalendarHeader({
+export default function CalenderHead({
   y,
   m,
   prevYear,
@@ -36,7 +36,7 @@ export default function CalendarHeader({
   nextMonth,
   nextYear,
   findToday,
-}: CalendarHeaderProps) {
+}: CalenderHeadProps) {
   return (
     <div className="flex h-33 flex-col items-center justify-center space-y-4 px-4 lg:h-22 lg:flex-row lg:items-center lg:justify-between lg:space-y-0 lg:px-8">
       <div className="flex h-fit w-fit items-center justify-center space-x-2">

--- a/src/app/(routers)/calendar/_components/CalenderHead.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderHead.tsx
@@ -1,0 +1,85 @@
+import Image from 'next/image';
+import largeGoal from '@/../public/images/large-goal.svg';
+
+import { Icon } from '@/components/icon/Icon';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface CalendarHeaderProps {
+  y: number;
+  m: number;
+  prevYear: () => void;
+  prevMonth: () => void;
+  nextMonth: () => void;
+  nextYear: () => void;
+  findToday: () => void;
+}
+
+const selectValue = [
+  { label: '전체 목표', value: 0 },
+  { label: '자바스크립트로 웹서비스 만들기', value: 1 },
+  { label: '디자인 시스템 정복하기', value: 2 },
+];
+
+export default function CalendarHeader({
+  y,
+  m,
+  prevYear,
+  prevMonth,
+  nextMonth,
+  nextYear,
+  findToday,
+}: CalendarHeaderProps) {
+  return (
+    <div className="flex h-33 flex-col items-center justify-center space-y-4 px-4 lg:h-22 lg:flex-row lg:items-center lg:justify-between lg:space-y-0 lg:px-8">
+      <div className="flex h-fit w-fit items-center justify-center space-x-2">
+        <div className="flex gap-2">
+          <Button variant="icon" size="none" onClick={prevYear}>
+            <Icon name="doubleArrow" direction="left" />
+          </Button>
+          <Button variant="icon" size="none" onClick={prevMonth}>
+            <Icon name="arrow" direction="left" />
+          </Button>
+        </div>
+        <span className="font-lg-semibold text-gray-800">
+          {y}년 {m + 1}월
+        </span>
+        <div className="flex items-center gap-2">
+          <Button variant="icon" size="none" onClick={nextMonth}>
+            <Icon name="arrow" direction="right" />
+          </Button>
+          <Button variant="icon" size="none" onClick={nextYear}>
+            <Icon name="doubleArrow" direction="right" />
+          </Button>
+          <Button variant="icon" size="none" onClick={findToday} className="text-gray-500">
+            today
+          </Button>
+        </div>
+      </div>
+      <Select items={selectValue}>
+        <SelectTrigger className="h-12 w-full lg:w-85">
+          <div className="font-sm-semibold flex items-center gap-2">
+            <Image src={largeGoal} alt="" width={20} height={20} />
+            <SelectValue />
+          </div>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {selectValue.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/app/(routers)/calendar/_components/CalenderHead.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderHead.tsx
@@ -41,10 +41,10 @@ export default function CalendarHeader({
     <div className="flex h-33 flex-col items-center justify-center space-y-4 px-4 lg:h-22 lg:flex-row lg:items-center lg:justify-between lg:space-y-0 lg:px-8">
       <div className="flex h-fit w-fit items-center justify-center space-x-2">
         <div className="flex gap-2">
-          <Button variant="icon" size="none" onClick={prevYear}>
+          <Button variant="icon" size="none" onClick={prevYear} aria-label="이전 연도로 이동">
             <Icon name="doubleArrow" direction="left" />
           </Button>
-          <Button variant="icon" size="none" onClick={prevMonth}>
+          <Button variant="icon" size="none" onClick={prevMonth} aria-label="이전 달로 이동">
             <Icon name="arrow" direction="left" />
           </Button>
         </div>
@@ -52,13 +52,19 @@ export default function CalendarHeader({
           {y}년 {m + 1}월
         </span>
         <div className="flex items-center gap-2">
-          <Button variant="icon" size="none" onClick={nextMonth}>
+          <Button variant="icon" size="none" onClick={nextMonth} aria-label="다음 달로 이동">
             <Icon name="arrow" direction="right" />
           </Button>
-          <Button variant="icon" size="none" onClick={nextYear}>
+          <Button variant="icon" size="none" onClick={nextYear} aria-label="다음 연도로 이동">
             <Icon name="doubleArrow" direction="right" />
           </Button>
-          <Button variant="icon" size="none" onClick={findToday} className="text-gray-500">
+          <Button
+            variant="icon"
+            size="none"
+            onClick={findToday}
+            className="text-gray-500"
+            aria-label="오늘 날짜로 이동"
+          >
             today
           </Button>
         </div>

--- a/src/app/(routers)/calendar/_components/CalenderPageHead.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderPageHead.tsx
@@ -4,9 +4,16 @@ import { Icon } from '@/components/icon/Icon';
 import { IconButton } from '@/components/ui/button';
 
 export default function CalenderPageHead() {
-  const userInfo = localStorage.getItem('user-info');
-  const parsedUserInfo = userInfo ? JSON.parse(userInfo).state : null;
-  const userName: string = parsedUserInfo.user.name ? parsedUserInfo.user.name : '';
+  const userInfo: string | null = localStorage.getItem('user-info');
+  let userName: string = '';
+  try {
+    const parsed = userInfo
+      ? (JSON.parse(userInfo) as { state?: { user?: { name?: string } } })
+      : null;
+    userName = parsed?.state?.user?.name ?? '';
+  } catch {
+    userName = '';
+  }
   return (
     <div className="hidden w-full items-center justify-between md:flex">
       <h1 className="font-xl-semibold lg:font-2xl-semibold">{userName}님의 캘린더</h1>

--- a/src/app/(routers)/calendar/_components/CalenderPageHead.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderPageHead.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Icon } from '@/components/icon/Icon';
+import { IconButton } from '@/components/ui/button';
+
+export default function CalenderPageHead() {
+  const userInfo = localStorage.getItem('user-info');
+  const parsedUserInfo = userInfo ? JSON.parse(userInfo).state : null;
+  const userName: string = parsedUserInfo.user.name ? parsedUserInfo.user.name : '';
+  return (
+    <div className="hidden w-full items-center justify-between md:flex">
+      <h1 className="font-xl-semibold lg:font-2xl-semibold">{userName}님의 캘린더</h1>
+      <IconButton variant="outline">
+        <Icon name="plus" variant="orange" />할 일 추가
+      </IconButton>
+    </div>
+  );
+}

--- a/src/app/(routers)/calendar/_components/CalenderScheduleList.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderScheduleList.tsx
@@ -1,0 +1,34 @@
+import type { Todo } from '@/api/todos';
+
+import { cn } from '@/lib';
+
+type CalendarTodo = Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>;
+
+interface CalendarScheduleListProps {
+  date: string;
+  todos: CalendarTodo[];
+}
+
+export default function CalendarScheduleList({ date, todos }: CalendarScheduleListProps) {
+  return (
+    <div className="flex h-69 flex-col gap-4 px-4 py-5 lg:hidden">
+      <h2 className="font-sm-semibold shrink-0">{date}</h2>
+      <div className="flex min-h-0 flex-1 flex-col space-y-[6px] overflow-y-scroll">
+        {todos.map((todo) => (
+          <div
+            key={todo.id}
+            className={cn(
+              'font-xs-semibold shrink-0 truncate rounded-[6px] border px-2 py-1',
+              todo.done
+                ? 'border-gray-300 bg-gray-50 text-gray-400'
+                : 'border-orange-300 bg-orange-100 text-orange-600',
+            )}
+          >
+            {todo.done ? '✓ ' : ''}
+            {todo.title}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(routers)/calendar/_components/CalenderScheduleList.tsx
+++ b/src/app/(routers)/calendar/_components/CalenderScheduleList.tsx
@@ -2,14 +2,14 @@ import type { Todo } from '@/api/todos';
 
 import { cn } from '@/lib';
 
-type CalendarTodo = Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>;
+type CalenderTodo = Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>;
 
-interface CalendarScheduleListProps {
+interface CalenderScheduleListProps {
   date: string;
-  todos: CalendarTodo[];
+  todos: CalenderTodo[];
 }
 
-export default function CalendarScheduleList({ date, todos }: CalendarScheduleListProps) {
+export default function CalenderScheduleList({ date, todos }: CalenderScheduleListProps) {
   return (
     <div className="flex h-69 flex-col gap-4 px-4 py-5 lg:hidden">
       <h2 className="font-sm-semibold shrink-0">{date}</h2>

--- a/src/app/(routers)/calendar/_components/ScheduleCalendar.tsx
+++ b/src/app/(routers)/calendar/_components/ScheduleCalendar.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { Todo } from '@/api/todos';
+
+import CalendarGrid from '@/app/(routers)/calendar/_components/CalenderGrid';
+import CalendarHeader from '@/app/(routers)/calendar/_components/CalenderHead';
+import CalendarScheduleList from '@/app/(routers)/calendar/_components/CalenderScheduleList';
+import { useScheduleCalendar } from '@/app/(routers)/calendar/hooks/useScheduleCalender';
+
+interface CalendarProps {
+  todos?: Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>[];
+}
+
+export default function ScheduleCalendar({ todos = [] }: CalendarProps) {
+  const {
+    y,
+    m,
+    cells,
+    totalCells,
+    selectedDate,
+    setSelectedDate,
+    selectedSchedule,
+    prevMonth,
+    nextMonth,
+    prevYear,
+    nextYear,
+    findToday,
+  } = useScheduleCalendar(todos);
+
+  return (
+    <div className="h-fit w-full rounded-[24px] bg-white lg:h-228">
+      <CalendarHeader
+        y={y}
+        m={m}
+        prevYear={prevYear}
+        prevMonth={prevMonth}
+        nextMonth={nextMonth}
+        nextYear={nextYear}
+        findToday={findToday}
+      />
+      <CalendarGrid
+        cells={cells}
+        totalCells={totalCells}
+        selectedDate={selectedDate}
+        onSelectDate={setSelectedDate}
+      />
+      <CalendarScheduleList date={selectedSchedule.date} todos={selectedSchedule.todos} />
+    </div>
+  );
+}

--- a/src/app/(routers)/calendar/_components/ScheduleCalender.tsx
+++ b/src/app/(routers)/calendar/_components/ScheduleCalender.tsx
@@ -2,16 +2,18 @@
 
 import type { Todo } from '@/api/todos';
 
-import CalendarGrid from '@/app/(routers)/calendar/_components/CalenderGrid';
-import CalendarHeader from '@/app/(routers)/calendar/_components/CalenderHead';
-import CalendarScheduleList from '@/app/(routers)/calendar/_components/CalenderScheduleList';
+import {
+  CalenderGrid,
+  CalenderHead,
+  CalenderScheduleList,
+} from '@/app/(routers)/calendar/_components/index';
 import { useScheduleCalendar } from '@/app/(routers)/calendar/hooks/useScheduleCalender';
 
-interface CalendarProps {
+interface CalenderProps {
   todos?: Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>[];
 }
 
-export default function ScheduleCalendar({ todos = [] }: CalendarProps) {
+export default function ScheduleCalender({ todos = [] }: CalenderProps) {
   const {
     y,
     m,
@@ -29,7 +31,7 @@ export default function ScheduleCalendar({ todos = [] }: CalendarProps) {
 
   return (
     <div className="h-fit w-full rounded-[24px] bg-white lg:h-228">
-      <CalendarHeader
+      <CalenderHead
         y={y}
         m={m}
         prevYear={prevYear}
@@ -38,13 +40,13 @@ export default function ScheduleCalendar({ todos = [] }: CalendarProps) {
         nextYear={nextYear}
         findToday={findToday}
       />
-      <CalendarGrid
+      <CalenderGrid
         cells={cells}
         totalCells={totalCells}
         selectedDate={selectedDate}
         onSelectDate={setSelectedDate}
       />
-      <CalendarScheduleList date={selectedSchedule.date} todos={selectedSchedule.todos} />
+      <CalenderScheduleList date={selectedSchedule.date} todos={selectedSchedule.todos} />
     </div>
   );
 }

--- a/src/app/(routers)/calendar/_components/index.ts
+++ b/src/app/(routers)/calendar/_components/index.ts
@@ -1,0 +1,6 @@
+export { default as CalenderPageHead } from './CalenderPageHead';
+export { default as CalenderHead } from './CalenderHead';
+export { default as CalenderScheduleList } from './CalenderScheduleList';
+export { default as CalenderGrid } from './CalenderGrid';
+export { default as BottomButton } from './BottomButton';
+export { default as ScheduleCalendar } from './ScheduleCalendar';

--- a/src/app/(routers)/calendar/_components/index.ts
+++ b/src/app/(routers)/calendar/_components/index.ts
@@ -3,4 +3,4 @@ export { default as CalenderHead } from './CalenderHead';
 export { default as CalenderScheduleList } from './CalenderScheduleList';
 export { default as CalenderGrid } from './CalenderGrid';
 export { default as BottomButton } from './BottomButton';
-export { default as ScheduleCalendar } from './ScheduleCalendar';
+export { default as ScheduleCalender } from './ScheduleCalender';

--- a/src/app/(routers)/calendar/hooks/useScheduleCalender.ts
+++ b/src/app/(routers)/calendar/hooks/useScheduleCalender.ts
@@ -1,0 +1,75 @@
+import type { Todo } from '@/api/todos';
+
+import { useState } from 'react';
+
+type CalendarTodo = Pick<Todo, 'id' | 'title' | 'dueDate' | 'done'>;
+
+function pad(n: number) {
+  return String(n).padStart(2, '0');
+}
+
+export function toDateStr(y: number, m: number, d: number) {
+  return `${y}-${pad(m + 1)}-${pad(d)}`;
+}
+
+export function useScheduleCalendar(todos: CalendarTodo[] = []) {
+  const today = new Date();
+  const todayStr = toDateStr(today.getFullYear(), today.getMonth(), today.getDate());
+
+  const [current, setCurrent] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(todayStr);
+
+  const y = current.getFullYear();
+  const m = current.getMonth();
+
+  const firstDay = new Date(y, m, 1).getDay();
+  const lastDate = new Date(y, m + 1, 0).getDate();
+  const prevLastDate = new Date(y, m, 0).getDate();
+  const totalCells = Math.ceil((firstDay + lastDate) / 7) * 7;
+
+  const cells = Array.from({ length: totalCells }, (_, i) => {
+    let day: number;
+    let dateStr: string;
+    let isOther = false;
+
+    if (i < firstDay) {
+      day = prevLastDate - firstDay + i + 1;
+      dateStr = toDateStr(m === 0 ? y - 1 : y, m === 0 ? 11 : m - 1, day);
+      isOther = true;
+    } else if (i >= firstDay + lastDate) {
+      day = i - firstDay - lastDate + 1;
+      dateStr = toDateStr(m === 11 ? y + 1 : y, m === 11 ? 0 : m + 1, day);
+      isOther = true;
+    } else {
+      day = i - firstDay + 1;
+      dateStr = toDateStr(y, m, day);
+    }
+
+    const dow = i % 7;
+    const isToday = dateStr === todayStr;
+    const dayTodos = todos.filter((t) => t.dueDate?.startsWith(dateStr));
+
+    return { day, dateStr, isOther, isToday, dow, dayTodos };
+  });
+
+  const selectedSchedule = {
+    date: selectedDate,
+    todos: todos.filter((t) => t.dueDate?.startsWith(selectedDate)),
+  };
+
+  return {
+    y,
+    m,
+    cells,
+    totalCells,
+    todayStr,
+    selectedDate,
+    setSelectedDate,
+    selectedSchedule,
+    prevMonth: () => setCurrent(new Date(y, m - 1, 1)),
+    nextMonth: () => setCurrent(new Date(y, m + 1, 1)),
+    prevYear: () => setCurrent(new Date(y - 1, m, 1)),
+    nextYear: () => setCurrent(new Date(y + 1, m, 1)),
+    findToday: () => setCurrent(today),
+  };
+}

--- a/src/app/(routers)/calendar/hooks/useScheduleCalender.ts
+++ b/src/app/(routers)/calendar/hooks/useScheduleCalender.ts
@@ -13,6 +13,18 @@ export function toDateStr(y: number, m: number, d: number) {
 }
 
 export function useScheduleCalendar(todos: CalendarTodo[] = []) {
+  const toLocalDateKey = (isoStr: string) => {
+    const d = new Date(isoStr);
+    if (Number.isNaN(d.getTime())) return null;
+    return toDateStr(d.getFullYear(), d.getMonth(), d.getDate());
+  };
+
+  const todosByDate = todos.reduce<Record<string, CalendarTodo[]>>((acc, todo) => {
+    const key = toLocalDateKey(todo.dueDate);
+    if (!key) return acc;
+    (acc[key] ??= []).push(todo);
+    return acc;
+  }, {});
   const today = new Date();
   const todayStr = toDateStr(today.getFullYear(), today.getMonth(), today.getDate());
 
@@ -47,14 +59,14 @@ export function useScheduleCalendar(todos: CalendarTodo[] = []) {
 
     const dow = i % 7;
     const isToday = dateStr === todayStr;
-    const dayTodos = todos.filter((t) => t.dueDate?.startsWith(dateStr));
+    const dayTodos = todosByDate[dateStr] ?? [];
 
     return { day, dateStr, isOther, isToday, dow, dayTodos };
   });
 
   const selectedSchedule = {
     date: selectedDate,
-    todos: todos.filter((t) => t.dueDate?.startsWith(selectedDate)),
+    todos: todosByDate[selectedDate] ?? [],
   };
 
   return {
@@ -70,6 +82,9 @@ export function useScheduleCalendar(todos: CalendarTodo[] = []) {
     nextMonth: () => setCurrent(new Date(y, m + 1, 1)),
     prevYear: () => setCurrent(new Date(y - 1, m, 1)),
     nextYear: () => setCurrent(new Date(y + 1, m, 1)),
-    findToday: () => setCurrent(today),
+    findToday: () => {
+      setCurrent(today);
+      setSelectedDate(todayStr);
+    },
   };
 }

--- a/src/app/(routers)/calendar/page.tsx
+++ b/src/app/(routers)/calendar/page.tsx
@@ -1,6 +1,6 @@
+import { ScheduleCalender } from '@/app/(routers)/calendar/_components';
 import BottomButton from '@/app/(routers)/calendar/_components/BottomButton';
 import CalenderPageHead from '@/app/(routers)/calendar/_components/CalenderPageHead';
-import ScheduleCalendar from '@/app/(routers)/calendar/_components/ScheduleCalendar';
 
 const mockTodos = [
   {
@@ -72,7 +72,7 @@ export default function CalenderPage() {
   return (
     <div className="relative flex h-full w-86 flex-col items-center pt-8 pb-14 md:w-159 md:space-y-6 lg:w-320 lg:space-y-4">
       <CalenderPageHead />
-      <ScheduleCalendar todos={mockTodos} />
+      <ScheduleCalender todos={mockTodos} />
       <div className="fixed bottom-0 flex h-16 w-full items-center justify-center border-t-1 bg-white px-4 md:hidden">
         <BottomButton />
       </div>

--- a/src/app/(routers)/calendar/page.tsx
+++ b/src/app/(routers)/calendar/page.tsx
@@ -1,8 +1,69 @@
+import BottomButton from '@/app/(routers)/calendar/_components/BottomButton';
+import CalenderPageHead from '@/app/(routers)/calendar/_components/CalenderPageHead';
+import ScheduleCalendar from '@/app/(routers)/calendar/_components/ScheduleCalendar';
+
+const mockTodos = [
+  {
+    id: 1,
+    title: '자바스크립트 기초 챕터1 듣기',
+    done: false,
+    dueDate: '2026-03-03T00:00:00.000Z',
+  },
+  {
+    id: 2,
+    title: '개발 환경 세팅하기 개발 환경 세팅하기 개발 환경 세팅하기',
+    done: true,
+    dueDate: '2026-03-10T00:00:00.000Z',
+  },
+  { id: 3, title: '사용자 테이블 설계', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  { id: 4, title: '목표 진행도 구현', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  { id: 5, title: 'JSON 서버 세팅', done: false, dueDate: '2026-03-15T00:00:00.000Z' },
+  { id: 6, title: '오류/로딩 상태 처리', done: true, dueDate: '2026-03-30T00:00:00.000Z' },
+  { id: 7, title: '오류/로딩 상태 처리 꼭하자', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  { id: 8, title: '오류/로딩 상태 처리 꼭하자8', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  { id: 9, title: '컴포넌트 분리 리팩토링', done: false, dueDate: '2026-03-05T00:00:00.000Z' },
+  { id: 10, title: 'API 연동 완료하기', done: true, dueDate: '2026-03-07T00:00:00.000Z' },
+  { id: 11, title: '단위 테스트 작성', done: false, dueDate: '2026-03-12T00:00:00.000Z' },
+  { id: 12, title: 'PR 리뷰 반영하기', done: true, dueDate: '2026-03-12T00:00:00.000Z' },
+  { id: 13, title: '스타일 가이드 문서화', done: false, dueDate: '2026-03-14T00:00:00.000Z' },
+  { id: 14, title: '다크모드 대응', done: false, dueDate: '2026-03-17T00:00:00.000Z' },
+  { id: 15, title: '접근성 개선', done: true, dueDate: '2026-03-17T00:00:00.000Z' },
+  { id: 16, title: '성능 최적화', done: false, dueDate: '2026-03-19T00:00:00.000Z' },
+  { id: 17, title: '배포 환경 설정', done: false, dueDate: '2026-03-20T00:00:00.000Z' },
+  { id: 18, title: '모바일 반응형 수정', done: true, dueDate: '2026-03-21T00:00:00.000Z' },
+  { id: 19, title: '캘린더 컴포넌트 구현', done: false, dueDate: '2026-03-24T00:00:00.000Z' },
+  { id: 20, title: '노트 에디터 연동', done: false, dueDate: '2026-03-24T00:00:00.000Z' },
+  { id: 21, title: '임시저장 기능 구현', done: true, dueDate: '2026-03-25T00:00:00.000Z' },
+  { id: 22, title: '검색 필터 디바운스 적용', done: false, dueDate: '2026-03-26T00:00:00.000Z' },
+  { id: 23, title: '낙관적 업데이트 적용', done: true, dueDate: '2026-03-27T00:00:00.000Z' },
+  { id: 24, title: '인터셉팅 라우트 버그 수정', done: false, dueDate: '2026-03-28T00:00:00.000Z' },
+  { id: 25, title: '최종 QA 진행', done: false, dueDate: '2026-03-31T00:00:00.000Z' },
+  { id: 26, title: '오류/로딩 상태 처리 꼭하자', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  { id: 27, title: '오류/로딩 상태 처리 꼭하자', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  {
+    id: 28,
+    title: '오류/로딩 상태 처리 꼭하자8 오류/로딩 상태 처리 꼭하자8 오류/로딩 상태 처리 꼭하자8',
+    done: false,
+    dueDate: '2026-03-10T00:00:00.000Z',
+  },
+  { id: 29, title: '오류/로딩 상태 처리 꼭하자', done: false, dueDate: '2026-03-10T00:00:00.000Z' },
+  {
+    id: 30,
+    title: '오류/로딩 상태 처리 꼭하자8',
+    done: false,
+    dueDate: '2026-03-10T00:00:00.000Z',
+  },
+  { id: 31, title: 'PR 리뷰 반영하기', done: true, dueDate: '2026-03-12T00:00:00.000Z' },
+  { id: 32, title: '머리카락 팔기', done: false, dueDate: '2026-03-12T00:00:00.000Z' },
+];
 export default function CalendarPage() {
   return (
-    <div className="h-svh bg-gray-100">
-      <h1>Calendar</h1>
-      <p>This is the calendar page.</p>
+    <div className="relative flex h-full w-86 flex-col items-center pt-8 pb-14 md:w-159 md:space-y-6 lg:w-320 lg:space-y-4">
+      <CalenderPageHead />
+      <ScheduleCalendar todos={mockTodos} />
+      <div className="fixed bottom-0 flex h-16 w-full items-center justify-center border-t-1 bg-white px-4 md:hidden">
+        <BottomButton />
+      </div>
     </div>
   );
 }

--- a/src/app/(routers)/calendar/page.tsx
+++ b/src/app/(routers)/calendar/page.tsx
@@ -55,6 +55,18 @@ const mockTodos = [
   },
   { id: 31, title: 'PR 리뷰 반영하기', done: true, dueDate: '2026-03-12T00:00:00.000Z' },
   { id: 32, title: '머리카락 팔기', done: false, dueDate: '2026-03-12T00:00:00.000Z' },
+  {
+    id: 33,
+    title: '한국은 3월 30일, UTC는 3월 29일',
+    done: false,
+    dueDate: '2026-03-29T16:00:00.000Z', // UTC 29일 16시 = 한국 30일 01시
+  },
+  {
+    id: 34,
+    title: '한국은 3월 1일, UTC는 2월 28일',
+    done: false,
+    dueDate: '2026-02-28T15:00:00.000Z', // UTC 2월 28일 15시 = 한국 3월 1일 00시
+  },
 ];
 export default function CalendarPage() {
   return (

--- a/src/app/(routers)/calendar/page.tsx
+++ b/src/app/(routers)/calendar/page.tsx
@@ -68,7 +68,7 @@ const mockTodos = [
     dueDate: '2026-02-28T15:00:00.000Z', // UTC 2월 28일 15시 = 한국 3월 1일 00시
   },
 ];
-export default function CalendarPage() {
+export default function CalenderPage() {
   return (
     <div className="relative flex h-full w-86 flex-col items-center pt-8 pb-14 md:w-159 md:space-y-6 lg:w-320 lg:space-y-4">
       <CalenderPageHead />

--- a/src/components/icon/icons/Plus.tsx
+++ b/src/components/icon/icons/Plus.tsx
@@ -1,6 +1,15 @@
 import type { SVGProps } from 'react';
 
-export const PlusIcon = (props: SVGProps<SVGSVGElement>) => {
+type PlusIconProps = SVGProps<SVGSVGElement> & {
+  variant?: 'default' | 'orange';
+};
+
+const variantStyles = {
+  default: 'white',
+  orange: 'var(--color-orange-600)',
+};
+
+export const PlusIcon = ({ variant = 'default', ...props }: PlusIconProps) => {
   return (
     <svg
       width="100%"
@@ -10,8 +19,18 @@ export const PlusIcon = (props: SVGProps<SVGSVGElement>) => {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <path d="M5 12H18.5" stroke="white" strokeWidth="1.8" strokeLinecap="round" />
-      <path d="M11.75 18.75V5.25" stroke="white" strokeWidth="1.8" strokeLinecap="round" />
+      <path
+        d="M5 12H18.5"
+        stroke={variantStyles[variant]}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+      <path
+        d="M11.75 18.75V5.25"
+        stroke={variantStyles[variant]}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
     </svg>
   );
 };

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { cn } from '@/lib';
+import { PreviewCard as PreviewCardPrimitive } from '@base-ui/react/preview-card';
+
+function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
+  return <PreviewCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({ ...props }: PreviewCardPrimitive.Trigger.Props) {
+  return <PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />;
+}
+
+function HoverCardContent({
+  className,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 4,
+  ...props
+}: PreviewCardPrimitive.Popup.Props &
+  Pick<PreviewCardPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  return (
+    <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+      <PreviewCardPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PreviewCardPrimitive.Popup
+          data-slot="hover-card-content"
+          className={cn(
+            'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 w-64 origin-(--transform-origin) rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100',
+            className,
+          )}
+          {...props}
+        />
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -3,13 +3,10 @@
 import * as React from 'react';
 import { cn } from '@/lib/shadcn';
 import { Select as SelectPrimitive } from '@base-ui/react/select';
-import {
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  Tick02Icon,
-  UnfoldMoreIcon,
-} from '@hugeicons/core-free-icons';
+import { ArrowDown01Icon, ArrowUp01Icon, Tick02Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
+
+import { Icon } from '@/components/icon/Icon';
 
 const Select = SelectPrimitive.Root;
 
@@ -85,15 +82,7 @@ function SelectTrigger({
     >
       {children}
       {size === 'default' && (
-        <SelectPrimitive.Icon
-          render={
-            <HugeiconsIcon
-              icon={UnfoldMoreIcon}
-              strokeWidth={2}
-              className="text-muted-foreground pointer-events-none size-4"
-            />
-          }
-        />
+        <SelectPrimitive.Icon render={<Icon name="arrow" direction="down" size={24} />} />
       )}
     </SelectPrimitive.Trigger>
   );


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.
캘린더 페이지 구현 — 월별 할일 일정을 캘린더 뷰로 확인하고 날짜별 할일 목록을 조회할 수 있는 페이지를 추가합니다.

- **관련 이슈:** Closes #155 
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 월별 캘린더 그리드 + 날짜 선택 시 하단 할일 목록 표시 (mobile/tablet)
- 데스크탑에서는 셀 내부에 할일 직접 표시, 초과 항목은 HoverCard로 표시

**컴포넌트 분리**
- `CalendarHeader` — 연/월 이동 버튼, today 버튼, 목표 필터 Select
- `CalendarGrid` — 요일 헤더 + 날짜 셀 그리드
  - mobile: 날짜별 dot으로 할일 유무 표시
  - desktop: 날짜 셀 내부에 할일 최대 3개 표시 + HoverCard로 초과 항목 표시
- `CalendarScheduleList` — 선택된 날짜의 할일 목록 (mobile/tablet 전용)

**커스텀 훅 분리**
- `useScheduleCalendar` — 날짜 계산, 셀 생성, 월 이동, 날짜 선택 상태 관리

**날짜 선택 UX**
- 초기 진입 시 오늘 날짜 자동 선택 (주황 원)
- 다른 날짜 선택 시 → 선택 날짜 주황 원, 오늘 날짜는 회색 원으로 유지
- today 버튼으로 현재 월로 즉시 이동

---
> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

**라이브러리 없이 직접 구현한 이유**

`react-big-calendar` 등 캘린더 라이브러리는 커스터마이징 자유도가 낮고 디자인 시스템과 맞추기 위해 많은 오버라이드가 필요합니다. 날짜 계산 로직이 단순하고 디자인이 이미 정해져 있어 직접 구현이 더 빠르고 유지보수에 유리했습니다.

**HoverCard를 초과 항목에 사용한 이유**

셀 높이가 고정되어 있어 할일이 많은 날짜는 잘려 보입니다. 모바일은 하단 리스트로 전체 확인이 가능하고, 데스크탑은 hover 인터랙션이 자연스러워 HoverCard로 초과 항목을 표시했습니다.

**`gridTemplateRows: repeat(N, 1fr)` 동적 적용 이유**

월마다 4주 또는 6주로 행 수가 달라집니다. 고정값 대신 `totalCells / 7`로 행 수를 계산해 컨테이너 높이를 항상 균등하게 채우도록 했습니다.

---

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. /calendar 페이지 진입
2. 오늘 날짜가 주황 원으로 강조되는지 확인
3. 다른 날짜 클릭 → 선택 날짜 주황 원, 오늘 날짜 회색 원으로 변경 확인
4. mobile/tablet: 하단에 선택 날짜의 할일 목록 표시 확인
5. desktop: 셀 내부에 할일 최대 3개 표시, +N개 hover 시 나머지 목록 확인
6. 이전/다음 월 이동, today 버튼으로 현재 월 복귀 확인
7. 할일 4개 이상인 날짜에서 HoverCard 동작 확인
```

**예상 결과:**
- 초기 진입 시 오늘 날짜 선택 + 해당 날짜 할일 목록 표시
- 월 이동 시 캘린더 그리드 정확히 업데이트
- 6주짜리 달(예: 2026년 3월)도 컨테이너 높이 균등하게 채움
- HoverCard는 desktop에서만 동작

---

## ⚠️ 리뷰어 참고사항

- 목표 필터 Select는 현재 mock 데이터로 구성되어 있습니다. 추후 `useGetGoals` 연동 예정입니다.
- HoverCard는 터치 디바이스에서 동작하지 않아 `hidden lg:block`으로 데스크탑 전용으로 제한했습니다.
- 캘린더 라이브러리 미사용으로 번들 사이즈 증가 없이 구현했습니다.
---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 월간 캘린더 뷰 추가 - 날짜 선택 및 일정 확인 가능
  * 월/연도 네비게이션 기능 추가
  * 사용자별 맞춤형 캘린더 헤더 표시
  * 목표 선택 드롭다운 메뉴 추가
  * 할 일 추가 버튼 추가

* **UI 개선**
  * 호버 카드 컴포넌트 추가
  * 아이콘 스타일 옵션 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->