### PR TITLE
Feat/82 post create api

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@tiptap/pm": "^3.20.4",
     "@tiptap/react": "^3.20.4",
     "@tiptap/starter-kit": "^3.20.4",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "components": "link:@/components",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.20.4
         version: 3.20.4
+      browser-image-compression:
+        specifier: ^2.0.2
+        version: 2.0.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2196,6 +2199,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browser-image-compression@2.0.2:
+    resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -4968,6 +4974,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uzip@0.20201231.0:
+    resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -7288,6 +7297,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-image-compression@2.0.2:
+    dependencies:
+      uzip: 0.20201231.0
 
   browserslist@4.28.1:
     dependencies:
@@ -10433,6 +10446,8 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  uzip@0.20201231.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/src/app/(routers)/(board)/community/CommunityClient.tsx
+++ b/src/app/(routers)/(board)/community/CommunityClient.tsx
@@ -90,7 +90,7 @@ export default function CommunityClient() {
     router.replace(`${pathname}?${params.toString()}`);
   };
 
-  if (isLoading || isFetching) return <PostListSkeleton />;
+  if (isLoading) return <PostListSkeleton />;
   if (isError && !data) return <PostErrorFallback onRetry={refetch} />;
 
   return (

--- a/src/app/(routers)/(board)/community/_api/communityApi.ts
+++ b/src/app/(routers)/(board)/community/_api/communityApi.ts
@@ -1,8 +1,9 @@
 import { apiClient } from '@/lib/apiClient.browser';
 
-export const uploadImages = async (file: File): Promise<string> => {
+export const uploadImage = async (file: File): Promise<string> => {
   const { uploadUrl, url } = await apiClient<{ uploadUrl: string; url: string }>('/images', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ fileName: file.name }),
   });
 

--- a/src/app/(routers)/(board)/community/_api/communityApi.ts
+++ b/src/app/(routers)/(board)/community/_api/communityApi.ts
@@ -7,7 +7,8 @@ export const uploadImage = async (file: File): Promise<string> => {
     body: JSON.stringify({ fileName: file.name }),
   });
 
-  await fetch(uploadUrl, { method: 'PUT', body: file });
+  const res = await fetch(uploadUrl, { method: 'PUT', body: file });
+  if (!res.ok) throw new Error('이미지 업로드에 실패했습니다.');
 
   return url;
 };

--- a/src/app/(routers)/(board)/community/_api/communityApi.ts
+++ b/src/app/(routers)/(board)/community/_api/communityApi.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/lib/apiClient.browser';
+
+export const uploadImages = async (file: File): Promise<string> => {
+  const { uploadUrl, url } = await apiClient<{ uploadUrl: string; url: string }>('/images', {
+    method: 'POST',
+    body: JSON.stringify({ fileName: file.name }),
+  });
+
+  await fetch(uploadUrl, { method: 'PUT', body: file });
+
+  return url;
+};

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -8,6 +8,7 @@ import type {
   User,
 } from '../types';
 
+import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/apiClient';
 import {
   keepPreviousData,
@@ -54,6 +55,25 @@ export const useGetPostById = (postId: number) => {
     queryFn: () => apiClient<Post>(`/posts/${postId}`),
     staleTime: 1000 * 60 * 5,
     enabled: Number.isInteger(postId) && postId > 0,
+  });
+};
+
+// 게시물 작성
+export const useCreatePost = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (post: PostInput) =>
+      apiClient<Post>('/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(post),
+      }),
+    onSuccess: (data) => {
+      queryClient.removeQueries({ queryKey: [...communityQueryKeys.all, 'posts'] });
+      router.replace(`/community/${data.id}`);
+    },
   });
 };
 

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -2,9 +2,9 @@ import type {
   Comment,
   CommentsResponse,
   Post,
+  PostInput,
   PostsResponse,
   SortOption,
-  UpdatePostInput,
   User,
 } from '../types';
 
@@ -62,7 +62,7 @@ export const useUpdatePost = (postId: number) => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (updatePost: UpdatePostInput) =>
+    mutationFn: (updatePost: PostInput) =>
       apiClient<Post>(`/posts/${postId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -71,6 +71,11 @@ export const useCreatePost = () => {
         body: JSON.stringify(post),
       }),
     onSuccess: (data) => {
+      queryClient.setQueryData(communityQueryKeys.post(data.id), data);
+      queryClient.setQueryData(communityQueryKeys.comments(data.id), {
+        comments: [],
+        totalCount: 0,
+      });
       queryClient.removeQueries({ queryKey: [...communityQueryKeys.all, 'posts'] });
       router.replace(`/community/${data.id}`);
     },

--- a/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
@@ -37,7 +37,11 @@ interface PostFormClientProps {
   mode: 'create' | 'edit';
   initialValues?: { title: string; content: string };
   initialImageUrls?: string[];
-  onSubmit?: (data: { title: string; contentJson: string }, images: File[]) => Promise<void>;
+  onSubmit?: (
+    data: { title: string; contentJson: string },
+    newFiles: File[],
+    existingUrls: string[],
+  ) => Promise<void>;
 }
 
 export function PostFormClient({
@@ -115,7 +119,13 @@ export function PostFormClient({
       const newFiles = images
         .filter((item): item is Extract<ImageItem, { type: 'new' }> => item.type === 'new')
         .map((item) => item.file);
-      await onSubmit?.({ title, contentJson }, newFiles);
+      const existingUrls = images
+        .filter(
+          (item): item is Extract<ImageItem, { type: 'existing' }> => item.type === 'existing',
+        )
+        .map((item) => item.url);
+
+      await onSubmit?.({ title, contentJson }, newFiles, existingUrls);
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : '게시물 저장에 실패했습니다.');

--- a/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
@@ -14,6 +14,7 @@ import { z } from 'zod';
 
 import { DeleteIcon } from '@/components/icon/icons/Delete';
 import { Toolbar } from '@/components/Toolbar';
+import { Spinner } from '@/components/ui/spinner';
 
 import { DesktopPostHeader } from './DesktopPostHeader';
 import { MobilePostHeader } from './MobilePostHeader';
@@ -202,6 +203,9 @@ export function PostFormClient({
           <div className="shrink-0 px-5 pt-6">
             <div className="hidden md:block">{toolbar}</div>
             <div className="flex items-center justify-between gap-2 md:mt-6">
+              {isSubmitting && (
+                <Spinner text={mode === 'create' ? '게시물 등록 중...' : '게시물 수정 중...'} />
+              )}
               <input
                 {...register('title')}
                 type="text"

--- a/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
@@ -122,6 +122,10 @@ export function PostFormClient({
     }
   });
 
+  const handleImageSizeExceeded = useCallback(() => {
+    toast.error('이미지 크기는 10MB를 초과할 수 없습니다.');
+  }, []);
+
   const handleImageLimitExceeded = useCallback(() => {
     toast.error(`이미지는 최대 ${IMAGE_LIMIT}개까지 첨부할 수 있습니다.`);
   }, []);
@@ -155,6 +159,7 @@ export function PostFormClient({
         onImageSelected={handleImageSelected}
         onImageLimitExceeded={handleImageLimitExceeded}
         externalImageCount={images.length}
+        onImageSizeExceeded={handleImageSizeExceeded}
       />
     ),
     [editor, images.length, handleImageSelected, handleImageLimitExceeded],
@@ -232,9 +237,12 @@ export function PostFormClient({
             </div>
           )}
 
-          <p className="font-xs-regular shrink-0 px-5 py-4 text-right text-gray-400 md:px-10 md:py-6 lg:px-14">
-            공백포함 {contentText.length}자 | 공백제외 {charCountWithoutSpaces}자
-          </p>
+          <div className="font-xs-regular flex shrink-0 justify-between px-5 py-4 text-gray-400 md:px-10 md:py-6 lg:px-14">
+            <p>이미지는 10MB 이하의 파일만 첨부할 수 있습니다. (최대 {IMAGE_LIMIT}까지)</p>
+            <p>
+              공백포함 {contentText.length}자 | 공백제외 {charCountWithoutSpaces}자
+            </p>
+          </div>
         </div>
       </div>
     </form>

--- a/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
@@ -25,7 +25,13 @@ export function PostSubmitClient({ mode, postId, initialValues, initialImageUrls
 
     const finalImageUrls = [...existingUrls, ...newUrls];
 
-    const json = JSON.parse(data.contentJson);
+    let json;
+    try {
+      json = JSON.parse(data.contentJson);
+    } catch {
+      throw new Error('게시물 내용이 올바르지 않습니다.');
+    }
+
     const imageNodes = finalImageUrls.map((url) => ({
       type: 'paragraph',
       content: [{ type: 'image', attrs: { src: url } }],

--- a/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { compressImage } from '../_utils/compressImage';
+import { PostFormClient } from './PostFormClient';
+
+interface Props {
+  mode: 'create' | 'edit';
+  postId?: number;
+  initialValues?: { title: string; content: string };
+  initialImageUrls?: string[];
+}
+
+export function PostSubmitClient({ mode, postId, initialValues, initialImageUrls }: Props) {
+  const handleSubmit = async (data: { title: string; contentJson: string }, images: File[]) => {
+    const compressedImages = await Promise.all(images.map(compressImage));
+
+    if (mode === 'create') {
+      // useCreatePost
+    } else {
+      // useUpdatePost
+    }
+  };
+
+  return (
+    <PostFormClient
+      mode={mode}
+      initialImageUrls={initialImageUrls}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { uploadImages } from '../_api/communityApi';
+import { uploadImage } from '../_api/communityApi';
+import { useCreatePost } from '../_api/communityQueries';
 import { compressImage } from '../_utils/compressImage';
 import { PostFormClient } from './PostFormClient';
 
@@ -12,18 +13,39 @@ interface Props {
 }
 
 export function PostSubmitClient({ mode, postId, initialValues, initialImageUrls }: Props) {
+  const { mutateAsync: createPost } = useCreatePost();
+
   const handleSubmit = async (
     data: { title: string; contentJson: string },
     newFiles: File[],
     existingUrls: string[],
   ) => {
     const compressedFiles = await Promise.all(newFiles.map(compressImage));
-    const newUrls = await Promise.all(compressedFiles.map(uploadImages));
+    const newUrls = await Promise.all(compressedFiles.map(uploadImage));
 
     const finalImageUrls = [...existingUrls, ...newUrls];
 
+    const json = JSON.parse(data.contentJson);
+    const imageNodes = finalImageUrls.map((url) => ({
+      type: 'paragraph',
+      content: [{ type: 'image', attrs: { src: url } }],
+    }));
+    const contentWithImages =
+      finalImageUrls.length > 0
+        ? JSON.stringify({
+            ...json,
+            content: [...json.content, ...imageNodes],
+          })
+        : data.contentJson;
+
+    const payload = {
+      title: data.title,
+      content: contentWithImages,
+      image: finalImageUrls[0] ?? null,
+    };
+
     if (mode === 'create') {
-      // useCreatePost
+      await createPost(payload);
     } else {
       // useUpdatePost
     }

--- a/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { uploadImages } from '../_api/communityApi';
 import { compressImage } from '../_utils/compressImage';
 import { PostFormClient } from './PostFormClient';
 
@@ -11,8 +12,15 @@ interface Props {
 }
 
 export function PostSubmitClient({ mode, postId, initialValues, initialImageUrls }: Props) {
-  const handleSubmit = async (data: { title: string; contentJson: string }, images: File[]) => {
-    const compressedImages = await Promise.all(images.map(compressImage));
+  const handleSubmit = async (
+    data: { title: string; contentJson: string },
+    newFiles: File[],
+    existingUrls: string[],
+  ) => {
+    const compressedFiles = await Promise.all(newFiles.map(compressImage));
+    const newUrls = await Promise.all(compressedFiles.map(uploadImages));
+
+    const finalImageUrls = [...existingUrls, ...newUrls];
 
     if (mode === 'create') {
       // useCreatePost

--- a/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostSubmitClient.tsx
@@ -12,7 +12,7 @@ interface Props {
   initialImageUrls?: string[];
 }
 
-export function PostSubmitClient({ mode, postId, initialValues, initialImageUrls }: Props) {
+export function PostSubmitClient({ mode, postId: _postId, initialValues, initialImageUrls }: Props) {
   const { mutateAsync: createPost } = useCreatePost();
 
   const handleSubmit = async (

--- a/src/app/(routers)/(board)/community/_utils/compressImage.ts
+++ b/src/app/(routers)/(board)/community/_utils/compressImage.ts
@@ -1,0 +1,9 @@
+import imageCompression from 'browser-image-compression';
+
+export const compressImage = (file: File): Promise<File> => {
+  return imageCompression(file, {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  });
+};

--- a/src/app/(routers)/(board)/community/new/page.tsx
+++ b/src/app/(routers)/(board)/community/new/page.tsx
@@ -1,5 +1,5 @@
-import { PostFormClient } from '../_components/PostFormClient';
+import { PostSubmitClient } from '../_components/PostSubmitClient';
 
 export default function NewPage() {
-  return <PostFormClient mode="create" />;
+  return <PostSubmitClient mode="create" />;
 }

--- a/src/app/(routers)/(board)/community/types.ts
+++ b/src/app/(routers)/(board)/community/types.ts
@@ -36,7 +36,7 @@ export interface PostsResponse {
   totalCount: number;
 }
 
-export interface UpdatePostInput {
+export interface PostInput {
   title: string;
   content: string;
   image?: string | null;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -14,6 +14,7 @@ interface ToolbarProps {
   imageLimit?: number;
   onLinkConfirm?: (url: string) => void;
   externalImageCount?: number;
+  onImageSizeExceeded?: () => void;
 }
 
 export function Toolbar({
@@ -24,6 +25,7 @@ export function Toolbar({
   imageLimit = 2,
   onLinkConfirm,
   externalImageCount = 0,
+  onImageSizeExceeded,
 }: ToolbarProps) {
   const { toolbarItems, fileInputRef, handleFileChange, showLinkModal, setShowLinkModal } =
     useToolbar({
@@ -33,6 +35,7 @@ export function Toolbar({
       onImageLimitExceeded,
       imageLimit,
       externalImageCount,
+      onImageSizeExceeded,
     });
 
   if (!editor) return null;

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/lib/shadcn';
+
+interface SpinnerProps {
+  className?: string;
+  text?: string;
+}
+
+function Spinner({ className, text }: SpinnerProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+      <div
+        className={cn(
+          'flex items-center gap-3 rounded-2xl bg-white px-6 py-4 shadow-lg',
+          className,
+        )}
+      >
+        <div className="size-5 animate-spin rounded-full border-[3px] border-orange-500 border-t-transparent" />
+        {text && <span className="font-base-medium text-gray-700">{text}</span>}
+      </div>
+    </div>
+  );
+}
+
+export { Spinner };

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -7,7 +7,12 @@ interface SpinnerProps {
 
 function Spinner({ className, text }: SpinnerProps) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+      role="status"
+      aria-live="polite"
+      aria-label={text || '로딩 중'}
+    >
       <div
         className={cn(
           'flex items-center gap-3 rounded-2xl bg-white px-6 py-4 shadow-lg',

--- a/src/hooks/editor/useToolbar.tsx
+++ b/src/hooks/editor/useToolbar.tsx
@@ -7,6 +7,8 @@ import { Icon } from '@/components/icon/Icon';
 
 type IconName = Parameters<typeof Icon>[0]['name'];
 
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+
 // variant별 툴바 버튼 표시 여부
 const TOOLBAR_CONFIG = {
   note: { showLink: true, showImage: false },
@@ -37,6 +39,7 @@ interface UseToolbarProps {
   onImageLimitExceeded?: () => void;
   imageLimit?: number;
   externalImageCount?: number;
+  onImageSizeExceeded?: () => void;
 }
 
 // 툴바 버튼 목록 및 이미지 업로드 동작을 관리하는 훅
@@ -47,6 +50,7 @@ export function useToolbar({
   onImageLimitExceeded,
   imageLimit = 2,
   externalImageCount = 0,
+  onImageSizeExceeded,
 }: UseToolbarProps) {
   // Tiptap은 자체 상태 관리라 React가 변경을 감지 못함 → forceUpdate로 버튼 활성 상태 동기화
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
@@ -97,6 +101,12 @@ export function useToolbar({
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    if (file.size > MAX_IMAGE_SIZE) {
+      onImageSizeExceeded?.();
+      e.target.value = '';
+      return;
+    }
 
     if (externalImageCount >= imageLimit) {
       onImageLimitExceeded?.();


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #82  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 이미지 첨부 시 10MB 용량 제한
- browser-image-compression으로 1MB 이하로 압축 후 S3 업로드
- S3 Presigned URL 방식으로 이미지 업로드
- PostSubmitClient 컴포넌트 추가 — 작성/수정 공통 submit 로직 분리
- useCreatePost 뮤테이션 추가, UpdatePostInput → PostInput 타입 통합
- Spinner 공통 컴포넌트 추가
- 게시글 작성 후 router.push → router.replace 변경
- 작성 성공 시 게시글/댓글 캐시 즉시 세팅

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 압축 타이밍: 파일 선택 시가 아닌 등록 버튼 클릭 시 압축 — 사용자가 이미지를 제거할 수도 있어 불필요한 연산 방지
- PostSubmitClient 분리: new/page.tsx는 서버 컴포넌트로 유지하면서 onSubmit 핸들러(클라이언트 로직)를 분리하기 위해. 작성/수정 두 곳에서 동일한 압축 → S3 → API 흐름을 공유
- setQueryData 방식: 작성 성공 후 상세 페이지 이동 시 스켈레톤 없이 바로 표시하기 위해 prefetchQuery(추가 API 호출) 대신 이미 받은 응답 데이터를 캐시에 직접 세팅. 댓글도 새 게시글은 당연히 없으므로 빈 배열로 즉시 세팅
- router.replace: 작성 후 상세 → 뒤로가기 시 작성 폼으로 돌아가는 UX 문제 방지

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

<img width="927" height="754" alt="스크린샷 2026-03-31 오후 3 32 49" src="https://github.com/user-attachments/assets/9e8afb9b-6f5b-4093-83fd-c197999f9743" />
<img width="928" height="749" alt="스크린샷 2026-03-31 오후 3 32 54" src="https://github.com/user-attachments/assets/1f3c2250-fc0f-4047-a42e-36d052718b32" />
<img width="932" height="753" alt="스크린샷 2026-03-31 오후 3 33 06" src="https://github.com/user-attachments/assets/4122e415-e047-4e90-a3f8-bfe1701d9819" />

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 소통게시판 → 게시물 작성하기
2. 제목 및 내용 입력
3. 이미지 첨부 (10MB 초과 파일로 제한 테스트)
4. 이미지 1개 또는 2개 첨부 후 등록 버튼 클릭
5. 등록 중 스피너 확인
6. 상세 페이지로 이동 (스켈레톤 없이 바로 표시되는지 확인)
7. 뒤로가기 시 목록 페이지로 이동되는지 확인
```

**예상 결과:**
- 10MB 초과 이미지 첨부 시 toast 에러 메시지 표시
- 등록 버튼 클릭 시 스피너 오버레이 표시
- 등록 완료 후 스켈레톤 없이 상세 페이지 바로 표시
- 상세 페이지에서 뒤로가기 시 목록으로 이동

- ...

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->
- 수정(edit) 모드는 다음 브랜치에서 구현 예정 (PostSubmitClient의 useUpdatePost 부분 미완성)
- 상세 페이지 이미지 렌더링 방식(tiptap content 내 노드 vs 별도 섹션)은 다음 브랜치에서 개선 예정
---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 커뮤니티 포스트 작성 시 이미지 업로드 및 압축(최대 1MB) 지원
  * 작성 폼에서 새로 추가한 이미지만 업로드하고 기존 이미지를 유지하는 제출 흐름 추가

* **개선사항**
  * 폼 제출 중 모드별 로딩 스피너 표시
  * 초기 로드에만 로딩 스켈레톤 표시하여 백그라운드 페칭 시 UI 유지
  * 10MB 초과 이미지 업로드 시 즉시 오류 알림 및 입력 초기화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->