### PR TITLE
Feat/188 post detail UI update

### DIFF
--- a/src/app/(routers)/(board)/community/CommunityClient.tsx
+++ b/src/app/(routers)/(board)/community/CommunityClient.tsx
@@ -2,9 +2,10 @@
 
 import type { Post, SortOption } from './types';
 
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import { Icon } from '@/components/icon/Icon';
 
@@ -13,7 +14,7 @@ import { FeaturedPostCard } from './_components/FeaturedPostCard';
 import { PostEmptyState } from './_components/PostEmptyState';
 import { PostErrorFallback } from './_components/PostErrorFallback';
 import { PostListItem } from './_components/PostListItem';
-import { PostListItemSkeleton, PostListSkeleton } from './_components/PostListSkeleton';
+import { PostListSkeleton } from './_components/PostListSkeleton';
 import { PostSearchBar } from './_components/PostSearchBar';
 import { extractPlainText } from './_utils/extractPlainText';
 
@@ -44,20 +45,12 @@ export default function CommunityClient() {
     [data],
   );
 
-  const observerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage && !search) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    if (observerRef.current) observer.observe(observerRef.current);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    enabled: !search,
+  });
 
   const featuredPosts = useMemo(
     () => [...posts].sort((a, b) => b.viewCount - a.viewCount).slice(0, 3),
@@ -131,7 +124,6 @@ export default function CommunityClient() {
             </div>
 
             <div ref={observerRef} className="h-4" />
-            {!search && isFetchingNextPage && <PostListItemSkeleton />}
             {!search && !hasNextPage && posts.length > 0 && (
               <p className="py-6 text-center text-sm text-gray-400">모든 게시물을 불러왔습니다.</p>
             )}

--- a/src/app/(routers)/(board)/community/CommunityClient.tsx
+++ b/src/app/(routers)/(board)/community/CommunityClient.tsx
@@ -144,7 +144,7 @@ export default function CommunityClient() {
         aria-label="게시물 작성하기"
         className="fixed right-4 bottom-8 flex size-[52px] items-center justify-center rounded-full bg-orange-500 shadow-lg md:right-8 md:size-auto md:gap-1 md:px-[18px] md:py-3.5"
       >
-        <Icon name="plus" size={24} variant="white" />
+        <Icon name="plus" size={24} />
         <span className="hidden text-lg font-semibold text-white md:block">게시물 작성하기</span>
       </Link>
     </div>

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import NextImage from 'next/image';
 import { useRouter } from 'next/navigation';
 import { authUserStore } from '@/stores/authUserStore';
 import Image from '@tiptap/extension-image';
@@ -14,6 +15,7 @@ import { KebabMenu } from '@/components/common/KebabMenu';
 import { useDeletePost, useGetComments, useGetPostById } from '../_api/communityQueries';
 import { PostErrorFallback } from '../_components/PostErrorFallback';
 import { WriterAvatar } from '../_components/WriterAvatar';
+import { extractImagesFromContent } from '../_utils/extractImagesFromContent';
 import { formatDate } from '../_utils/formatDate';
 import { CommentSection } from './_components/CommentSection';
 import { PostDetailSkeleton } from './_components/PostDetailSkeleton';
@@ -43,22 +45,22 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
   const router = useRouter();
 
   const editor = useEditor({
-    extensions: [
-      StarterKit,
-      TextAlign.configure({ types: ['heading', 'paragraph'] }),
-      Image,
-    ],
+    extensions: [StarterKit, TextAlign.configure({ types: ['heading', 'paragraph'] }), Image],
     content: '',
     editable: false,
     immediatelyRender: false,
   });
 
+  const { contentWithoutImages, imageUrls } = post
+    ? extractImagesFromContent(post.content)
+    : { contentWithoutImages: '', imageUrls: [] };
+
   useEffect(() => {
     if (editor && post) {
       try {
-        editor.commands.setContent(JSON.parse(post.content));
+        editor.commands.setContent(JSON.parse(contentWithoutImages));
       } catch {
-        editor.commands.setContent(post.content ?? '');
+        editor.commands.setContent(contentWithoutImages ?? '');
       }
       setContentReady(true);
     }
@@ -118,6 +120,22 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
                 editor={editor}
                 className="mt-6 [&_img]:mt-4 [&_img]:h-auto [&_img]:w-full [&_img]:max-w-[232px] [&_img]:rounded-[20px]"
               />
+
+              {imageUrls.length > 0 && (
+                <div className="mt-4 flex gap-2">
+                  {imageUrls.map((url, i) => (
+                    <div key={i} className="relative size-[150px] shrink-0 md:size-[232px]">
+                      <NextImage
+                        src={url}
+                        alt={`첨부 이미지 ${i + 1}`}
+                        fill
+                        unoptimized
+                        className="rounded-xl object-cover"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
 
               <div className="font-xs-regular mt-4 flex gap-1 text-gray-400">
                 <span>{formatDate(createdAt)}</span>

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import type { Comment } from '../types';
-
 import { useEffect, useMemo, useState } from 'react';
 import NextImage from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -27,31 +25,17 @@ interface PostDetailClientProps {
 }
 
 export function PostDetailClient({ postId }: PostDetailClientProps) {
+  useGetComments(postId);
   const { data: post, isLoading: isPostLoading, isError, refetch } = useGetPostById(postId);
-  const {
-    data: commentsData,
-    isLoading: isCommentsLoading,
-    isError: isCommentsError,
-    isFetching: isCommentsFetching,
-    refetch: refetchComments,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useGetComments(postId);
   const user = authUserStore((state) => state.user);
   const userId = Number(user?.id);
-
-  const comments: Comment[] = useMemo(() => {
-    const all = (commentsData?.pages ?? []).flatMap((page) => page.comments);
-    return Array.from(new Map(all.map((c) => [c.id, c])).values());
-  }, [commentsData]);
 
   const { mutate: deletePost, isPending: isPostDeleting } = useDeletePost();
   const isWriter = userId === post?.userId;
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isCommentBusy, setIsCommentBusy] = useState(false);
-  const isBusy = isCommentBusy || isPostDeleting || isCommentsFetching;
+  const isBusy = isCommentBusy || isPostDeleting;
   const [contentReady, setContentReady] = useState(false);
   const router = useRouter();
 
@@ -77,18 +61,10 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
       }
       setContentReady(true);
     }
-  }, [editor, post]);
+  }, [editor, post, contentWithoutImages]);
 
-  if ((isError && !post) || isCommentsError)
-    return (
-      <PostErrorFallback
-        onRetry={() => {
-          void refetch();
-          void refetchComments();
-        }}
-      />
-    );
-  if (isPostLoading || isCommentsLoading) return <PostDetailSkeleton />;
+  if (isError && !post) return <PostErrorFallback onRetry={refetch} />;
+  if (isPostLoading) return <PostDetailSkeleton />;
   if (!post) return <PostErrorFallback onRetry={refetch} />;
   if (!contentReady) return <PostDetailSkeleton />;
 
@@ -159,14 +135,10 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
 
             <CommentSection
               postId={postId}
-              comments={comments}
               totalCount={commentCount}
               userId={userId}
-              isBusy={isBusy}
+              isPostDeleting={isPostDeleting}
               onPendingChange={setIsCommentBusy}
-              fetchNextPage={fetchNextPage}
-              hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
             />
           </div>
         </div>

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -62,9 +62,11 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
     immediatelyRender: false,
   });
 
-  const { contentWithoutImages, imageUrls } = post
-    ? extractImagesFromContent(post.content)
-    : { contentWithoutImages: '', imageUrls: [] };
+  const { contentWithoutImages, imageUrls } = useMemo(
+    () =>
+      post ? extractImagesFromContent(post.content) : { contentWithoutImages: '', imageUrls: [] },
+    [post],
+  );
 
   useEffect(() => {
     if (editor && post) {
@@ -77,7 +79,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
     }
   }, [editor, post]);
 
-  if ((isError && !post) || (isCommentsError && !comments))
+  if ((isError && !post) || isCommentsError)
     return (
       <PostErrorFallback
         onRetry={() => {

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import type { Comment } from '../types';
+
+import { useEffect, useMemo, useState } from 'react';
 import NextImage from 'next/image';
 import { useRouter } from 'next/navigation';
 import { authUserStore } from '@/stores/authUserStore';
@@ -27,20 +29,29 @@ interface PostDetailClientProps {
 export function PostDetailClient({ postId }: PostDetailClientProps) {
   const { data: post, isLoading: isPostLoading, isError, refetch } = useGetPostById(postId);
   const {
-    data: comments,
+    data: commentsData,
     isLoading: isCommentsLoading,
     isError: isCommentsError,
+    isFetching: isCommentsFetching,
     refetch: refetchComments,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
   } = useGetComments(postId);
   const user = authUserStore((state) => state.user);
   const userId = Number(user?.id);
+
+  const comments: Comment[] = useMemo(() => {
+    const all = (commentsData?.pages ?? []).flatMap((page) => page.comments);
+    return Array.from(new Map(all.map((c) => [c.id, c])).values());
+  }, [commentsData]);
 
   const { mutate: deletePost, isPending: isPostDeleting } = useDeletePost();
   const isWriter = userId === post?.userId;
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isCommentBusy, setIsCommentBusy] = useState(false);
-  const isBusy = isCommentBusy || isPostDeleting;
+  const isBusy = isCommentBusy || isPostDeleting || isCommentsFetching;
   const [contentReady, setContentReady] = useState(false);
   const router = useRouter();
 
@@ -79,7 +90,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
   if (!post) return <PostErrorFallback onRetry={refetch} />;
   if (!contentReady) return <PostDetailSkeleton />;
 
-  const { title, viewCount, createdAt, writer } = post;
+  const { title, viewCount, createdAt, writer, commentCount } = post;
 
   const kebabItems = [
     { label: '수정하기', onClick: () => router.push(`/community/${postId}/edit`) },
@@ -147,9 +158,13 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
             <CommentSection
               postId={postId}
               comments={comments}
+              totalCount={commentCount}
               userId={userId}
               isBusy={isBusy}
               onPendingChange={setIsCommentBusy}
+              fetchNextPage={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
             />
           </div>
         </div>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -1,29 +1,36 @@
 'use client';
 
-import type { CommentsResponse } from '../../types';
+import type { Comment } from '../../types';
 
 import { useEffect, useState } from 'react';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import { useCreateComment, useDeleteComment } from '../../_api/communityQueries';
 import { CommentItem } from './CommentItem';
 
 interface CommentSectionProps {
   postId: number;
-  comments: CommentsResponse | undefined;
+  comments: Comment[];
+  totalCount: number;
   userId: number | undefined;
   isBusy?: boolean;
   onPendingChange?: (isPending: boolean) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
 }
 
 export function CommentSection({
   postId,
   comments,
+  totalCount,
   userId,
   isBusy = false,
   onPendingChange,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
 }: CommentSectionProps) {
-  const commentList = comments?.comments ?? [];
-  const totalCount = comments?.totalCount ?? 0;
   const [inputValue, setInputValue] = useState('');
   const { mutate: createComment, isPending: isCreating } = useCreateComment(postId);
   const { mutate: deleteComment, isPending: isDeleting } = useDeleteComment(postId);
@@ -31,6 +38,12 @@ export function CommentSection({
   useEffect(() => {
     onPendingChange?.(isCreating || isDeleting);
   }, [isCreating, isDeleting, onPendingChange]);
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const handleSubmit = () => {
     if (!inputValue.trim() || isCreating) return;
@@ -75,7 +88,7 @@ export function CommentSection({
       </div>
 
       <ul className="flex flex-col gap-8 md:gap-10">
-        {commentList.map((comment) => (
+        {comments.map((comment) => (
           <CommentItem
             key={comment.id}
             comment={comment}
@@ -85,6 +98,7 @@ export function CommentSection({
           />
         ))}
       </ul>
+      <div ref={observerRef} className="h-4" />
     </div>
   );
 }

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -2,38 +2,47 @@
 
 import type { Comment } from '../../types';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
-import { useCreateComment, useDeleteComment } from '../../_api/communityQueries';
+import { useCreateComment, useDeleteComment, useGetComments } from '../../_api/communityQueries';
 import { CommentItem } from './CommentItem';
 
 interface CommentSectionProps {
   postId: number;
-  comments: Comment[];
   totalCount: number;
   userId: number | undefined;
-  isBusy?: boolean;
+  isPostDeleting?: boolean;
   onPendingChange?: (isPending: boolean) => void;
-  hasNextPage: boolean;
-  isFetchingNextPage: boolean;
-  fetchNextPage: () => void;
 }
 
 export function CommentSection({
   postId,
-  comments,
   totalCount,
   userId,
-  isBusy = false,
+  isPostDeleting = false,
   onPendingChange,
-  hasNextPage,
-  isFetchingNextPage,
-  fetchNextPage,
 }: CommentSectionProps) {
+  const {
+    data: commentsData,
+    isError,
+    isFetching,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetComments(postId);
+
+  const comments: Comment[] = useMemo(() => {
+    const all = (commentsData?.pages ?? []).flatMap((page) => page.comments);
+    return Array.from(new Map(all.map((c) => [c.id, c])).values());
+  }, [commentsData]);
+
   const [inputValue, setInputValue] = useState('');
   const { mutate: createComment, isPending: isCreating } = useCreateComment(postId);
   const { mutate: deleteComment, isPending: isDeleting } = useDeleteComment(postId);
+
+  const isBusy = isPostDeleting || isFetching;
 
   useEffect(() => {
     onPendingChange?.(isCreating || isDeleting);
@@ -80,25 +89,40 @@ export function CommentSection({
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={!inputValue.trim() || isBusy}
+          disabled={!inputValue.trim() || isBusy || isCreating}
           className="font-sm-semibold md:font-base-semibold w-16 shrink-0 rounded-full bg-orange-500 py-2.5 text-white disabled:cursor-not-allowed disabled:bg-gray-300 md:w-20 md:py-3"
         >
           등록
         </button>
       </div>
 
-      <ul className="flex flex-col gap-8 md:gap-10">
-        {comments.map((comment) => (
-          <CommentItem
-            key={comment.id}
-            comment={comment}
-            isMyComment={comment.userId === userId}
-            onDelete={deleteComment}
-            isDeleting={isBusy}
-          />
-        ))}
-      </ul>
-      <div ref={observerRef} className="h-4" />
+      {isError ? (
+        <div className="flex flex-col items-center gap-2 py-6 text-center">
+          <p className="font-sm-regular text-gray-500">댓글을 불러오지 못했습니다.</p>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="font-sm-medium text-orange-500 underline"
+          >
+            다시 시도
+          </button>
+        </div>
+      ) : (
+        <>
+          <ul className="flex flex-col gap-8 md:gap-10">
+            {comments.map((comment) => (
+              <CommentItem
+                key={comment.id}
+                comment={comment}
+                isMyComment={comment.userId === userId}
+                onDelete={deleteComment}
+                isDeleting={isBusy}
+              />
+            ))}
+          </ul>
+          <div ref={observerRef} className="h-4" />
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -64,8 +64,8 @@ export const useCreatePost = () => {
     onSuccess: (data) => {
       queryClient.setQueryData(communityQueryKeys.post(data.id), data);
       queryClient.setQueryData(communityQueryKeys.comments(data.id), {
-        comments: [],
-        totalCount: 0,
+        pages: [{ comments: [], totalCount: 0, nextCursor: null }],
+        pageParams: [undefined],
       });
       queryClient.removeQueries({ queryKey: [...communityQueryKeys.all, 'posts'] });
       router.replace(`/community/${data.id}`);
@@ -129,11 +129,16 @@ export const useCreateComment = (postId: number) => {
 
 // 댓글 목록 조회
 export const useGetComments = (postId: number) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: communityQueryKeys.comments(postId),
-    queryFn: () => apiClient<CommentsResponse>(`/posts/${postId}/comments`),
+    queryFn: ({ pageParam }) =>
+      apiClient<CommentsResponse>(
+        `/posts/${postId}/comments?limit=5${pageParam ? `&cursor=${pageParam}` : ''}`,
+      ),
     staleTime: 1000 * 60 * 5,
     enabled: Number.isInteger(postId) && postId > 0,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 };
 

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+export function useInfiniteScroll({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  enabled = true,
+}: {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  enabled?: boolean;
+}) {
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage && enabled) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    if (observerRef.current) observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, enabled]);
+
+  return { observerRef };
+}


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #188 <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- `extractImagesFromContent` 유틸 함수로 tiptap content에서 이미지 노드를 분리하여 에디터 하단에 가로 나열로 렌더링
- `useGetComments`를 `useInfiniteQuery`로 변경하고 커서 기반 페이지네이션 적용
- `IntersectionObserver`를 `useInfiniteScroll` 공통 훅으로 추상화 (`enabled` 옵션으로 검색 모드 비활성화 지원)
- `isBusy` 조건에 `isCommentsFetching` 추가하여 댓글 목록 갱신 완료 전 재등록 방지

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 게시물 작성 폼과 동일한 이미지 레이아웃으로 일관성 유지
- 댓글이 많아질 경우 초기 로딩 부담을 줄이기 위해 무한 스크롤 도입
- `useInfiniteScroll` 훅을 게시물 목록과 댓글에서 공유하여 중복 제거
- 댓글 등록 API 응답 직후 `isCreating`이 false가 되어 목록 refetch 완료 전 버튼이 활성화되는 시간차 문제 수정

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전]<img width="932" height="753" alt="스크린샷 2026-03-31 오후 3 33 06" src="https://github.com/user-attachments/assets/af32a59b-9b98-40b4-a0d3-1799cb72c56e" /> | ![변경 후]<img width="1321" height="750" alt="스크린샷 2026-04-01 오전 10 51 33" src="https://github.com/user-attachments/assets/6fa45c40-37a4-4773-8624-6012719f1cf6" /> |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 소통게시판 게시물 상세 페이지 진입
2. 이미지가 포함된 게시물에서 이미지가 본문 하단에 가로 나열되는지 확인
3. 댓글이 5개 이상인 게시물에서 스크롤 시 추가 댓글 로드 확인
4. 댓글 등록 시 등록 버튼이 목록 갱신 완료까지 비활성화 유지 확인
5. 댓글 삭제 후 목록이 정상 갱신되는지 확인
```

**예상 결과:**
- 이미지가 본문과 분리되어 하단에 나열됨
- 스크롤 하단 도달 시 다음 페이지 댓글 자동 로드
- 댓글 등록/삭제 중 버튼 비활성화 유지


---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 커뮤니티 댓글에 무한 스크롤 지원 추가
  * 게시물 이미지가 본문에서 분리되어 별도 갤러리(썸네일)로 표시

* **개선 사항**
  * 댓글 페이징 및 로드 흐름 개선으로 일관된 스크롤 페이징 제공
  * 댓글/게시물 로딩 UI와 에러 처리 간소화
  * 댓글 작성/삭제 중 버튼 비활성화 및 로딩 상태 표시 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->