### PR TITLE
🐛 fix(proxy): update bff logic

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -258,7 +258,7 @@ describe('proxy', () => {
       expect(calledUrl).toContain('sort=desc');
     });
 
-    it('바디 있음(multipart 등) → upstream fetch에 duplex: half 전달', async () => {
+    it('바디 있음(multipart 등) → upstream fetch에 ArrayBuffer 바디(스트림·duplex 미사용)', async () => {
       (globalThis.fetch as jest.Mock).mockResolvedValue(
         new Response(JSON.stringify({ ok: true }), { status: 200 }),
       );
@@ -276,17 +276,21 @@ describe('proxy', () => {
       });
       await forwardToBackend(req, 'upload');
 
+      const fetchOpts = (globalThis.fetch as jest.Mock).mock.calls[0][1] as RequestInit & {
+        duplex?: string;
+      };
+      expect(fetchOpts.duplex).toBeUndefined();
+      expect(fetchOpts.body).toBeInstanceOf(ArrayBuffer);
+      expect(fetchOpts.body).not.toBeUndefined();
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/upload'),
         expect.objectContaining({
           method: 'POST',
-          duplex: 'half',
-          body: expect.anything(),
         }),
       );
     });
 
-    it('POST /goals — JSON 바디(title)가 업스트림으로 전달되고 duplex·Authorization·identity 적용', async () => {
+    it('POST /goals — JSON 바디(title)가 업스트림으로 전달되고 Authorization·identity 적용', async () => {
       (globalThis.fetch as jest.Mock).mockResolvedValue(
         new Response(JSON.stringify({ id: '1', title: '프로젝트 완성' }), { status: 201 }),
       );
@@ -309,19 +313,21 @@ describe('proxy', () => {
         expect.stringMatching(/\/goals$/),
         expect.objectContaining({
           method: 'POST',
-          duplex: 'half',
-          body: expect.anything(),
+          body: expect.any(ArrayBuffer),
         }),
       );
 
-      const fetchOpts = (globalThis.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      const fetchOpts = (globalThis.fetch as jest.Mock).mock.calls[0][1] as RequestInit & {
+        duplex?: string;
+      };
+      expect(fetchOpts.duplex).toBeUndefined();
       const upstreamHeaders = fetchOpts.headers as Headers;
       expect(upstreamHeaders.get('Accept-Encoding')).toBe('identity');
       expect(upstreamHeaders.get('Authorization')).toMatch(/^Bearer /);
 
-      const streamed = fetchOpts.body;
-      expect(streamed).toBeDefined();
-      const forwardedJson = JSON.parse(await new Response(streamed as BodyInit).text());
+      const buf = fetchOpts.body as ArrayBuffer;
+      expect(buf).toBeDefined();
+      const forwardedJson = JSON.parse(Buffer.from(buf).toString('utf8'));
       expect(forwardedJson).toEqual(payload);
     });
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -177,16 +177,22 @@ export async function forwardToBackend(request: Request, path: string): Promise<
    * ERR_CONTENT_DECODING_FAILED가 날 수 있음 — 백엔드 요청만 비압축으로 고정.
    */
   headers.set('Accept-Encoding', 'identity');
+  /**
+   * 스트림 바디 + `duplex: 'half'` 업스트림 fetch는 로컬에선 동작해도 Vercel 등 서버리스에서
+   * undici/Request 조합으로 예외 → 500(빈 바디)이 나는 경우가 있음.
+   * 바디를 버퍼로 읽어 넘기면 duplex 불필요·Content-Length 일치.
+   */
+  headers.delete('content-length');
+  headers.delete('transfer-encoding');
 
-  /** Node.js: ReadableStream 바디 전달 시 안전한 요청 처리를 위해 요청과 응답 스트림 분리 `duplex: half` 필요 (multipart 등) */
-  const upstreamInit: RequestInit & { duplex?: 'half' } = {
-    method: request.method,
-    headers,
-    body: request.body,
-  };
-  if (request.body) {
-    upstreamInit.duplex = 'half';
+  const method = request.method;
+  let body: BodyInit | undefined;
+  if (method !== 'GET' && method !== 'HEAD' && request.body) {
+    const buf = await request.arrayBuffer();
+    if (buf.byteLength > 0) {
+      body = buf;
+    }
   }
 
-  return fetch(url, upstreamInit);
+  return fetch(url, { method, headers, body });
 }


### PR DESCRIPTION
- 수정된 proxy 요청 처리로 ArrayBuffer 바디 사용 및 duplex 옵션 제거

---

# 📋 PR 개요

> Vercel 배포 환경에서 BFF `/api/proxy`로 **POST·PUT·PATCH 등 mutation 요청 시 500(응답 바디 없음)** 이 나던 문제를, 업스트림 `fetch`에 **스트림 + `duplex: 'half'` 대신 `ArrayBuffer` 바디**를 넘기도록 바꿔 해결하였습니다.

- **관련 이슈:** Closes #193 
- **PR 유형:**
  - [ ] ✨ `feat`
  - [x] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor`
  - [ ] 🎨 `style`
  - [ ] ⚡ `perf`
  - [x] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore`
  - [ ] 📝 `docs`

---

## 🔍 변경 사항 (What & Why)

**What**

- `forwardToBackend`에서 `GET`/`HEAD`가 아니고 `request.body`가 있으면 `await request.arrayBuffer()`로 읽은 뒤, 그 버퍼만 업스트림 `fetch`의 `body`로 전달한다.
- 업스트림 요청 전에 `content-length`, `transfer-encoding` 헤더를 제거해(fetch가 새 바디 기준으로 길이를 맞추도록) 클라이언트가 넘긴 값과의 불일치를 방지한다.
- 기존의 `body: request.body` + `duplex: 'half'` 경로는 제거한다.
- `proxy.test.ts`에서 multipart·JSON POST 케이스를 **ArrayBuffer 전달·duplex 미사용** 기준으로 수정한다.

**Why**

- Node(undici)에서 인입 `Request`의 **ReadableStream 바디**를 그대로 넘기며 `duplex: 'half'`를 쓰는 조합이, 로컬에서는 되어도 **Vercel 서버리스**에서 예외가 나 Next가 **500 + 빈 응답**으로 떨어지는 경우가 있습니다.
- 바디를 한 번 버퍼로 읽으면 `duplex`가 필요 없고, 동작이 서버리스에서도 안정적입니다.
- 대안으로는 Edge 런타임 전환, 별도 프록시 레이어 등이 있으나, 변경 범위·리스크 대비 **버퍼링이 가장 단순**합니다. (대용량 멀티파트는 Vercel 본문 한도·메모리와 트레이드오프가 있음.)

---

## ✅ 체크리스트

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [x] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료 — 해당 없음
- [ ] `tsc --noEmit` 통과 확인 — 제출 전 로컬에서 확인

### 테스트

- [x] 새로운 기능에 대한 테스트 작성 완료 — 기대 동작을 테스트로 반영
- [ ] 기존 테스트 모두 통과 (`pnpm test`) — 제출 전 실행
- [x] 엣지 케이스 고려 완료 — 빈 바디·GET/HEAD는 기존 로직 유지

### UI/UX (프론트엔드 변경 시)

- 해당 없음 (BFF/서버 로직만 변경)

### 보안 & 성능

- [x] 민감 정보 노출 없음 (token, password, key 등)
- [x] N+1 쿼리 발생 없음 — 해당 없음
- [x] 불필요한 리렌더링 없음 — 해당 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

UI 변경 없음 — 생략.

---

## 🧪 테스트 방법

```text
1. `pnpm test` — `src/__tests__/proxy.test.ts` 포함 전체 통과 확인
2. (선택) Vercel 프리뷰 또는 프로덕션에서 로그인 후 브라우저로 mutation 호출
   - 예: `POST /api/proxy/todos` (JSON 바디)
3. 배포 환경에서 500이 아니고 백엔드와 동일한 상태 코드·바디가 오는지 확인
```

**예상 결과:**

- 로컬·Vercel 모두에서 mutation이 **500 빈 응답 없이** 백엔드 프록시 결과를 반환한다.

---

## ⚠️ 리뷰어 참고사항

- `forwardToBackend`는 요청 바디를 **메모리에 버퍼링**한다. 매우 큰 업로드는 플랫폼 본문 한도·메모리와 맞춰 별도 전략이 필요할 수 있다.

---

## 📎 참고 자료

- [Node/undici: 스트림 바디 `fetch` 시 `duplex` 관련 동작](https://undici.nodejs.org/#/?id=undicifetchinput-init-promise)
- [Vercel: Serverless 함수 요청 본문 제한(플랜별)](https://vercel.com/docs/functions/limitations)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 프록시 요청 처리 개선으로 파일 업로드 및 폼 데이터 전송 시 안정성 향상
  * 업스트림 요청 전달 시 헤더 처리 최적화로 프록시 호환성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->