### PR TITLE
🚸 feat(auth): enhance auth flow with session redirection

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -67,6 +67,39 @@ describe('proxy', () => {
       expect(res.status).toBe(200);
     });
 
+    it('/login + access 또는 refresh → redirect (callbackUrl 없으면 /dashboard)', () => {
+      const reqAccess = createRequest('/login', { access: 'valid-token' });
+      expect(proxy(reqAccess).headers.get('location')).toMatch(/\/dashboard$/);
+      expect(proxy(reqAccess).status).toBe(307);
+
+      const reqRefresh = createRequest('/login', { refresh: 'refresh-only' });
+      expect(proxy(reqRefresh).headers.get('location')).toMatch(/\/dashboard$/);
+      expect(proxy(reqRefresh).status).toBe(307);
+    });
+
+    it('/login + 세션 + callbackUrl(안전) → 해당 경로로 redirect', () => {
+      const req = createRequest(
+        `/login?${new URLSearchParams({ callbackUrl: '/profile' }).toString()}`,
+        { access: 'valid-token' },
+      );
+      const res = proxy(req);
+      expect(res.headers.get('location')).toMatch(/\/profile$/);
+      expect(res.status).toBe(307);
+    });
+
+    it('/login + 세션 + ?error= → OAuth 실패 처리용으로 next() (리다이렉트 안 함)', () => {
+      const req = createRequest('/login?error=access_denied', { access: 'valid-token' });
+      const res = proxy(req);
+      expect(res.status).toBe(200);
+    });
+
+    it('/signup + 세션 → /dashboard로 redirect', () => {
+      const req = createRequest('/signup', { access: 'valid-token' });
+      const res = proxy(req);
+      expect(res.headers.get('location')).toMatch(/\/dashboard$/);
+      expect(res.status).toBe(307);
+    });
+
     it('루트 "/" + access 또는 refresh 있음 → redirect /dashboard', () => {
       const reqAccess = createRequest('/', { access: 'valid-token' });
       expect(proxy(reqAccess).headers.get('location')).toMatch(/\/dashboard$/);

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,12 @@
+import { redirectIfSessionOnAuthPage } from '@/lib/auth/redirectIfSessionOnAuthPage';
+
 import LoginForm from '../_features/LoginForm';
 
-export default function LoginPage() {
+type LoginPageProps = {
+  searchParams: Promise<{ callbackUrl?: string | string[]; error?: string | string[] }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  await redirectIfSessionOnAuthPage(await searchParams);
   return <LoginForm />;
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,5 +1,12 @@
+import { redirectIfSessionOnAuthPage } from '@/lib/auth/redirectIfSessionOnAuthPage';
+
 import SignupForm from '../_features/SignupForm';
 
-export default function SignupPage() {
+type SignupPageProps = {
+  searchParams: Promise<{ callbackUrl?: string | string[]; error?: string | string[] }>;
+};
+
+export default async function SignupPage({ searchParams }: SignupPageProps) {
+  await redirectIfSessionOnAuthPage(await searchParams);
   return <SignupForm />;
 }

--- a/src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitle.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitle.tsx
@@ -1,16 +1,12 @@
-import type { User } from '@/lib/auth/schemas/user';
-
 import { getCurrentUser } from '@/lib/auth/getCurrentUser.server';
+
+import { DashboardTitleClient } from './DashboardTitleClient';
 
 /**
  * @ //TODO:  추후 이 타이틀이 모바일일 경우 사이드바 제목으로 이동해야 한다.
+ * @note 표시 우선순위는 {@link DashboardTitleClient} — persist → 서버 `getCurrentUser`.
  */
-export const DashboardTitle = async () => {
-  const user: User | null = await getCurrentUser();
-  const name = user?.name ?? '손';
-  return (
-    <header className="dashboard-title pt-12 pb-7 md:pt-20 md:pb-10">
-      <h1 className="font-base-semibold md:font-xl-semibold lg:text-2xl-semibold text-black">{`${name}님의 대시보드`}</h1>
-    </header>
-  );
-};
+export async function DashboardTitle() {
+  const initialUser = await getCurrentUser();
+  return <DashboardTitleClient initialUser={initialUser} />;
+}

--- a/src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitleClient.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitleClient.tsx
@@ -14,7 +14,10 @@ type DashboardTitleClientProps = {
  */
 export function DashboardTitleClient({ initialUser }: DashboardTitleClientProps) {
   const storeUser = useUserInfo();
-  const user = storeUser ?? initialUser;
+  const user =
+    storeUser && initialUser && storeUser.email !== initialUser.email
+      ? initialUser
+      : (storeUser ?? initialUser);
   return (
     <header className="dashboard-title pt-12 pb-7 md:pt-20 md:pb-10">
       <h1 className="font-base-semibold md:font-xl-semibold lg:text-2xl-semibold text-black">{`${user?.name ?? '손'}님의 대시보드`}</h1>

--- a/src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitleClient.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitleClient.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { User } from '@/lib/auth/schemas/user';
+
+import { useUserInfo } from '@/hooks/auth/useUserInfo';
+
+type DashboardTitleClientProps = {
+  /** 서버 `getCurrentUser()` — persist에 없거나 서버만 맞을 때 사용 */
+  initialUser: User | null;
+};
+
+/**
+ * persist(`authUserStore`)가 있으면 우선, 없으면 `initialUser`.
+ */
+export function DashboardTitleClient({ initialUser }: DashboardTitleClientProps) {
+  const storeUser = useUserInfo();
+  const user = storeUser ?? initialUser;
+  return (
+    <header className="dashboard-title pt-12 pb-7 md:pt-20 md:pb-10">
+      <h1 className="font-base-semibold md:font-xl-semibold lg:text-2xl-semibold text-black">{`${user?.name ?? '손'}님의 대시보드`}</h1>
+    </header>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,4 @@
 import Image from 'next/image';
-import { redirect } from 'next/navigation';
-import { hasAuthSessionCookies } from '@/lib/auth/cookies';
 
 import { FeatureCard } from './_components/FeatureCard';
 import { StartButton } from './_components/StartButton';
@@ -9,11 +7,7 @@ import { STEPS } from './_constants/steps';
 /** 비로그인 CTA는 로그인 후 대시보드로 — 보호 라우트·`/signup` 예외는 `proxy` + `isPublicPath` */
 const START_HREF = `/login?${new URLSearchParams({ callbackUrl: '/dashboard' }).toString()}`;
 
-export default async function HomePage() {
-  if (await hasAuthSessionCookies()) {
-    redirect('/dashboard');
-  }
-
+export default function HomePage() {
   return (
     <main className="min-dvh font-pretendard flex flex-col bg-white **:tracking-[-0.03em] dark:bg-black">
       <section className="hero flex w-full flex-col items-center justify-center bg-[linear-gradient(220deg,#FFF9E5_20.84%,#D4FFFE_93.31%)] px-6 pt-20">

--- a/src/lib/auth/__tests__/redirectIfSessionOnAuthPage.test.ts
+++ b/src/lib/auth/__tests__/redirectIfSessionOnAuthPage.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { redirect } from 'next/navigation';
+import { hasAuthSessionCookies } from '@/lib/auth/cookies';
+import { redirectIfSessionOnAuthPage } from '@/lib/auth/redirectIfSessionOnAuthPage';
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((to: string) => {
+    const err = new Error('NEXT_REDIRECT');
+    (err as Error & { digest?: string }).digest = to;
+    throw err;
+  }),
+}));
+
+jest.mock('@/lib/auth/cookies', () => ({
+  hasAuthSessionCookies: jest.fn(),
+}));
+
+const mockHas = hasAuthSessionCookies as jest.MockedFunction<typeof hasAuthSessionCookies>;
+const mockRedirect = redirect as jest.MockedFunction<typeof redirect>;
+
+describe('redirectIfSessionOnAuthPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('error 쿼리가 있으면 redirect·hasAuthSessionCookies 호출 안 함', async () => {
+    mockHas.mockResolvedValue(true);
+    await redirectIfSessionOnAuthPage({ error: 'access_denied' });
+    expect(mockHas).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('error가 공백만 있으면 무시하지 않고 스킵하지 않음 — trim 후 비어 있으면 통과', async () => {
+    mockHas.mockResolvedValue(true);
+    await expect(redirectIfSessionOnAuthPage({ error: '   ' })).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('세션 없으면 redirect 안 함', async () => {
+    mockHas.mockResolvedValue(false);
+    await redirectIfSessionOnAuthPage({});
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('세션 있으면 /dashboard', async () => {
+    mockHas.mockResolvedValue(true);
+    await expect(redirectIfSessionOnAuthPage({})).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('callbackUrl 안전하면 해당 경로', async () => {
+    mockHas.mockResolvedValue(true);
+    await expect(redirectIfSessionOnAuthPage({ callbackUrl: '/profile' })).rejects.toThrow(
+      'NEXT_REDIRECT',
+    );
+    expect(mockRedirect).toHaveBeenCalledWith('/profile');
+  });
+});

--- a/src/lib/auth/redirectIfSessionOnAuthPage.ts
+++ b/src/lib/auth/redirectIfSessionOnAuthPage.ts
@@ -1,0 +1,25 @@
+import 'server-only';
+
+import { redirect } from 'next/navigation';
+import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
+
+import { hasAuthSessionCookies } from './cookies';
+
+function pickFirst(v: string | string[] | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+/**
+ * 로그인/회원가입 RSC: 세션 쿠키가 있으면 대시보드 또는 안전한 `callbackUrl`로 보냄.
+ * OAuth 실패 `?error=` 가 있으면 리다이렉트하지 않음 (`proxy.ts` 와 동일 정책).
+ */
+export async function redirectIfSessionOnAuthPage(searchParams: {
+  callbackUrl?: string | string[];
+  error?: string | string[];
+}): Promise<void> {
+  if (pickFirst(searchParams.error)?.trim()) return;
+  if (!(await hasAuthSessionCookies())) return;
+  const raw = pickFirst(searchParams.callbackUrl);
+  redirect(getSafeCallbackPath(raw ?? null) ?? '/dashboard');
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,8 +2,9 @@ import 'server-only';
 
 import type { NextRequest } from 'next/server';
 
-import { isPublicPath } from '@/lib/navigation/publicPaths';
 import { NextResponse } from 'next/server';
+import { isPublicPath } from '@/lib/navigation/publicPaths';
+import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
 import { ALLOWED_ORIGINS, API_BASE_URL } from '@/constants/api';
 import { AUTH_CONFIG, isAuthRouteGuardEnabled } from '@/constants/auth-config';
@@ -25,7 +26,7 @@ export { isPublicPath, PUBLIC_PATHS } from '@/lib/navigation/publicPaths';
 
 /**
  * @description proxy - Next.js 16 라우트 보호 (proxy.ts = 구 middleware.ts)
- * @note `/` + access·refresh 중 하나라도 있으면 `/dashboard`로 리다이렉트(랜딩 스킵).
+ * @note 세션(access·refresh 중 하나) 있을 때: `/` → `/dashboard`; `/login`·`/signup` → 안전한 `callbackUrl` 또는 `/dashboard`(OAuth 실패 `?error=` 는 로그인/가입만 스킵).
  * @note access만 없고 refresh가 있으면 **통과** — 세션 복구 가능(클라이언트 `POST /api/auth/refresh` 등으로 access 재발급).
  *       둘 다 없을 때만 로그인으로 보냄.
  * @param request - NextRequest
@@ -38,10 +39,21 @@ export function proxy(request: NextRequest) {
 
   const hasAccess = Boolean(accessCookie?.value);
   const hasRefresh = Boolean(refreshCookie?.value);
+  const hasSession = hasAccess || hasRefresh;
 
-  /** 랜딩(`/`)은 공개지만, 세션 쿠키가 있으면 대시보드로 (미들웨어에서 `proxy` 호출 시) */
-  if (pathname === '/' && (hasAccess || hasRefresh)) {
-    return NextResponse.redirect(new URL('/dashboard', request.url));
+  /** 세션 있으면 랜딩·인증 화면 스킵 — OAuth 콜백 실패 `?error=` 는 로그인/가입에서만 리다이렉트 생략 */
+  if (hasSession) {
+    if (pathname === '/') {
+      return NextResponse.redirect(new URL('/dashboard', request.url));
+    }
+    if (
+      (pathname === '/login' || pathname === '/signup') &&
+      !request.nextUrl.searchParams.get('error')?.trim()
+    ) {
+      const nextPath =
+        getSafeCallbackPath(request.nextUrl.searchParams.get('callbackUrl')) ?? '/dashboard';
+      return NextResponse.redirect(new URL(nextPath, request.url));
+    }
   }
 
   if (isPublicPath(pathname)) {


### PR DESCRIPTION
- login이 유효할 때 `/`, `/login`, `/signup` url을 `/dashboard`로 redirect
- dashboard 제목 페이지 리팩터링
- proxy 수정 관련하여 테스트 케이스 추가

# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #285  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [x] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?

| 구역 | 내용 |
| --- | --- |
| [`src/proxy.ts`](src/proxy.ts) | `hasSession` 한 블록에서 `/` → `/dashboard`, `/login`·`/signup` → `getSafeCallbackPath(callbackUrl) ?? '/dashboard'`. OAuth 실패 시 `?error=` 가 있으면 로그인/가입만 리다이렉트 안 함. |
| [`src/lib/auth/redirectIfSessionOnAuthPage.ts`](src/lib/auth/redirectIfSessionOnAuthPage.ts) | RSC에서 세션 쿠키가 있으면 동일 정책으로 리다이렉트 (미들웨어 미호출 환경 대비). |
| [`src/app/(auth)/login/page.tsx`](src/app/(auth)/login/page.tsx), [`signup/page.tsx`](src/app/(auth)/signup/page.tsx) | `redirectIfSessionOnAuthPage(await searchParams)` 적용. |
| [`src/app/page.tsx`](src/app/page.tsx) | `hasAuthSessionCookies` + `redirect` 제거 — 루트 세션 스킵은 `proxy`와 역할 중복 제거. |
| 대시보드 타이틀 | [`DashboardTitle.tsx`](src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitle.tsx)는 async 서버에서 `getCurrentUser()`, [`DashboardTitleClient.tsx`](src/app/(routers)/(dashboard)/dashboard/_components/DashboardTitleClient.tsx)에서 `useUserInfo() ?? initialUser`. |
| 테스트 | [`src/__tests__/proxy.test.ts`](src/__tests__/proxy.test.ts), [`src/lib/auth/__tests__/redirectIfSessionOnAuthPage.test.ts`](src/lib/auth/__tests__/redirectIfSessionOnAuthPage.test.ts) |

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

- 세션·공개 경로 정책을 `proxy`와 RSC가 같은 규칙으로 맞춤.
- 타이틀은 서버에서 `React.cache`된 `getCurrentUser`로 첫 데이터를 보장하고, 클라이언트 persist가 있으면 그걸 우선해 로그인 직후 UX를 맞춤.(Zustand Persist를 사용하고, 없으면 서버 컴포넌트에서 가져옴 캐싱 장점과 동시에 fallback 고려함)

- 로그인/가입 리다이렉트를 `proxy`만 쓰기: 현재 레포는 `proxy`가 항상 요청마다 실행된다는 가정이 어려워 RSC 보조를 둠.


<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [x] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [x] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [x] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법
```text
1. `dev` 브랜치 대비 diff: `git diff dev...HEAD`
2. `pnpm test` — `proxy.test`, `redirectIfSessionOnAuthPage.test` 포함 전체 통과 확인
3. `pnpm tsc --noEmit`
4. 로그인 상태에서 `/`, `/login`, `/signup` 접속 시 `/dashboard`(또는 안전한 callbackUrl)로 이동하는지 확인
5. `/login?error=...` (OAuth 실패 등)로 접속 시 로그인 화면 유지·리다이렉트 되지 않는지 확인
6. 대시보드 타이틀에 사용자 이름이 표시되는지 (persist 우선, 없으면 서버 유저)
```

**예상 결과:**

- 세션 있을 때 랜딩·로그인·가입 경로가 의도대로 스킵된다.
- 타이틀 이름이 persist 또는 서버 유저 중 사용 가능한 쪽으로 표시된다.

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인/회원가입 접근 시 인증된 사용자는 대시보드로 자동 리다이렉트됩니다.
  * 리다이렉트 대상으로 콜백 URL을 안전하게 지정할 수 있습니다.
  * 대시보드 제목이 클라이언트 측에서 사용자 정보에 따라 동적으로 표시됩니다.

* **버그 수정**
  * 세션 기반 리다이렉트 및 오류 처리 로직 개선으로 예외 상황에서의 불필요한 리다이렉트 감소

* **테스트**
  * 로그인/회원가입과 리다이렉트 관련 다양한 시나리오 검증 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->