### PR TITLE
Feat/277 favorites improvements

### DIFF
--- a/src/app/(routers)/(board)/community/CommunityClient.tsx
+++ b/src/app/(routers)/(board)/community/CommunityClient.tsx
@@ -8,11 +8,11 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import { EmptyState } from '@/components/EmptyState';
+import { ErrorFallback } from '@/components/ErrorFallback';
 import { Icon } from '@/components/icon/Icon';
 
 import { useGetPosts } from './_api/communityQueries';
 import { FeaturedPostCard } from './_components/FeaturedPostCard';
-import { PostErrorFallback } from './_components/PostErrorFallback';
 import { PostListItem } from './_components/PostListItem';
 import { PostListSkeleton } from './_components/PostListSkeleton';
 import { PostSearchBar } from './_components/PostSearchBar';
@@ -84,7 +84,7 @@ export default function CommunityClient() {
   };
 
   if (isLoading) return <PostListSkeleton />;
-  if (isError && !data) return <PostErrorFallback onRetry={refetch} />;
+  if (isError && !data) return <ErrorFallback onRetry={refetch} title="소통 게시판" />;
 
   return (
     <div className="relative h-full w-full">

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -14,9 +14,9 @@ import { formatDate } from '@/utils/date';
 
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
+import { ErrorFallback } from '@/components/ErrorFallback';
 
 import { useDeletePost, useGetComments, useGetPostById } from '../_api/communityQueries';
-import { PostErrorFallback } from '../_components/PostErrorFallback';
 import { WriterAvatar } from '../_components/WriterAvatar';
 import { extractImagesFromContent } from '../_utils/extractImagesFromContent';
 import { CommentSection } from './_components/CommentSection';
@@ -65,9 +65,9 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
     }
   }, [editor, post, contentWithoutImages]);
 
-  if (isError && !post) return <PostErrorFallback onRetry={refetch} />;
+  if (isError && !post) return <ErrorFallback onRetry={refetch} title="소통 게시판" />;
   if (isPostLoading) return <PostDetailSkeleton />;
-  if (!post) return <PostErrorFallback onRetry={refetch} />;
+  if (!post) return <ErrorFallback onRetry={refetch} title="소통 게시판" />;
   if (!contentReady) return <PostDetailSkeleton />;
 
   const { title, viewCount, createdAt, writer, commentCount } = post;

--- a/src/app/(routers)/favorites/_components/FavoritesTab.tsx
+++ b/src/app/(routers)/favorites/_components/FavoritesTab.tsx
@@ -122,7 +122,7 @@ export default function FavoritesTab() {
           </SelectContent>
         </Select>
 
-        <div ref={observerRef} className="flex flex-col">
+        <div className="flex flex-col">
           {filtered.length > 0 ? (
             filtered.map((fav) => <TodoItem key={fav.todo.id} task={toTask(fav)} />)
           ) : (
@@ -136,6 +136,7 @@ export default function FavoritesTab() {
               )}
             </div>
           )}
+          <div ref={observerRef} className="h-4" />
         </div>
       </div>
     </div>

--- a/src/app/(routers)/favorites/_components/FavoritesTab.tsx
+++ b/src/app/(routers)/favorites/_components/FavoritesTab.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib';
 
 import TodoItem from '@/components/common/TodoItem';
 import { EmptyState } from '@/components/EmptyState';
+import { ErrorFallback } from '@/components/ErrorFallback';
 import {
   Select,
   SelectContent,
@@ -33,7 +34,8 @@ export default function FavoritesTab() {
   const [selectedGoalId, setSelectedGoalId] = useState<string>('all');
   const [goalSelectOpen, setGoalSelectOpen] = useState(false);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useGetFavorites();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =
+    useGetFavorites();
   const favorites: Favorite[] = useMemo(
     () => (data?.pages ?? []).flatMap((page) => page.favorites),
     [data],
@@ -66,6 +68,7 @@ export default function FavoritesTab() {
   });
 
   if (isLoading) return <FavoritesTabSkeleton />;
+  if (isError) return <ErrorFallback onRetry={() => refetch()} title="찜한 할 일" />;
 
   return (
     <div className="flex h-full flex-col">

--- a/src/app/(routers)/favorites/_components/FavoritesTab.tsx
+++ b/src/app/(routers)/favorites/_components/FavoritesTab.tsx
@@ -68,7 +68,7 @@ export default function FavoritesTab() {
   });
 
   if (isLoading) return <FavoritesTabSkeleton />;
-  if (isError) return <ErrorFallback onRetry={() => refetch()} title="찜한 할 일" />;
+  if (isError) return <ErrorFallback onRetry={refetch} title="찜한 할 일" />;
 
   return (
     <div className="flex h-full flex-col">

--- a/src/app/(routers)/favorites/_components/FavoritesTab.tsx
+++ b/src/app/(routers)/favorites/_components/FavoritesTab.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/select';
 
 import { toTask, useGetFavorites } from '../_api/favoritesQueries';
+import { FavoritesTabSkeleton } from './FavoritesTabSkeleton';
 
 type Tab = 'ALL' | 'TODO' | 'DONE';
 
@@ -32,7 +33,7 @@ export default function FavoritesTab() {
   const [selectedGoalId, setSelectedGoalId] = useState<string>('all');
   const [goalSelectOpen, setGoalSelectOpen] = useState(false);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetFavorites();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useGetFavorites();
   const favorites: Favorite[] = useMemo(
     () => (data?.pages ?? []).flatMap((page) => page.favorites),
     [data],
@@ -63,6 +64,8 @@ export default function FavoritesTab() {
     if (tab === 'DONE') return fav.todo.done;
     return true;
   });
+
+  if (isLoading) return <FavoritesTabSkeleton />;
 
   return (
     <div className="flex h-full flex-col">

--- a/src/app/(routers)/favorites/_components/FavoritesTabSkeleton.tsx
+++ b/src/app/(routers)/favorites/_components/FavoritesTabSkeleton.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function FavoritesTabSkeleton() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-6 hidden items-center gap-2 md:flex">
+        <Skeleton variant="gray" className="h-7 w-24" />
+        <Skeleton variant="gray" className="h-7 w-8" />
+      </div>
+
+      <div className="mb-3 flex gap-1">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} variant="gray" className="h-7 w-14 rounded-full" />
+        ))}
+      </div>
+
+      <div className="flex flex-1 flex-col rounded-[28px] bg-white p-4 shadow-sm md:p-6">
+        <Skeleton variant="gray" className="mb-4 h-13 w-full rounded-xl" />
+
+        <div className="flex flex-col">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 rounded-2xl px-2 py-3 md:px-4 md:py-4 lg:px-8"
+            >
+              <Skeleton variant="gray" className="h-[22px] w-[22px] shrink-0 rounded" />
+              <Skeleton
+                variant="gray"
+                className="h-6 rounded"
+                style={{ width: `${[30, 40, 25, 35, 30, 40][i % 6]}%` }}
+              />
+              <Skeleton variant="gray" className="ml-auto h-6 w-6 shrink-0 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,12 +1,13 @@
-interface PostErrorFallbackProps {
+interface ErrorFallbackProps {
   onRetry: () => void;
+  title: string;
 }
 
-export function PostErrorFallback({ onRetry }: PostErrorFallbackProps) {
+export function ErrorFallback({ onRetry, title }: ErrorFallbackProps) {
   return (
     <div className="h-full w-full bg-gray-100 px-4 py-6 md:px-8 md:py-12">
       <h1 className="font-xl-semibold md:font-2xl-semibold mb-6 px-2 text-black md:mb-8">
-        소통 게시판
+        {title}
       </h1>
       <div className="flex flex-col items-center gap-4 py-40">
         <p className="font-3xl-regular mb-4 text-gray-600">데이터를 불러오지 못했어요.</p>


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #277  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 찜한 할 일 페이지 로딩 중 스켈레톤 UI 추가
- 데이터 로드 실패 시 에러 상태 및 재시도 버튼 추가
- ErrorFallback 공통 컴포넌트로 분리하여 재사용 가능하도록 개선
- observerRef 위치를 리스트 하단으로 이동하여 무한 스크롤 정상 동작

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 로딩/에러 상태 없이 빈 화면이 노출되어 사용자 경험 저하
- observerRef가 빈 상태 분기 안에만 존재해 아이템이 있을 때 Intersection Observer가 동작하지 않아 다음 페이지 fetch가 트리거되지 않음
- PostErrorFallback이 하드코딩된 타이틀로 재사용 불가한 구조였음

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)
<img width="1227" height="749" alt="스크린샷 2026-04-07 오후 2 24 50" src="https://github.com/user-attachments/assets/a4b353f4-f19e-4515-87f2-36a2efa60e06" />
<img width="1226" height="752" alt="스크린샷 2026-04-07 오후 2 24 18" src="https://github.com/user-attachments/assets/4d0e3d77-eb75-4c41-b641-c6769b8f493a" />


---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 찜한 할 일 페이지 접속
2. 스켈레톤 UI가 표시되는지 확인
3. 에러 상태 및 "다시 시도하기" 버튼이 표시되는지 확인
4. "다시 시도하기" 버튼 클릭 후 재요청 되는지 확인
5. 찜한 할 일이 20개 이상인 계정으로 접속 후 스크롤을 끝까지 내려 다음 페이지가 로드되는지 확인
```

**예상 결과:**
- 로딩 중 TodoItem 구조와 유사한 스켈레톤이 표시됨
- 에러 시 "데이터를 불러오지 못했어요" 메시지와 재시도 버튼 노출
- 재시도 버튼 클릭 시 데이터 재요청
- 리스트 끝까지 스크롤 시 다음 페이지 자동 로드

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 즐겨찾기 탭에 로딩용 스켈레톤 UI 추가로 로딩 경험 향상.

* **Bug Fixes**
  * 여러 화면에서 오류 시 일관된 오류 화면으로 통일 및 재시도 제공.
  * 무한 스크롤 감지 위치 변경으로 스크롤 로딩 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->