### PR TITLE
Feat/298 post comment update

### DIFF
--- a/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
@@ -1,7 +1,7 @@
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
 import { cn } from '@/lib';
-import z from 'zod';
+import { z } from 'zod';
 
 export const commentSchema = z.object({
   content: z

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
@@ -1,0 +1,56 @@
+import type { UseFormRegisterReturn } from 'react-hook-form';
+
+import { cn } from '@/lib';
+import z from 'zod';
+
+export const commentSchema = z.object({
+  content: z
+    .string()
+    .min(1, '댓글을 입력해주세요')
+    .max(500, '댓글은 최대 500자까지 입력할 수 있습니다.'),
+});
+
+export type CommentForm = z.infer<typeof commentSchema>;
+
+interface CommentInputProps {
+  register: UseFormRegisterReturn;
+  contentLength?: number;
+  disabled?: boolean;
+  variant?: 'create' | 'edit';
+}
+
+export function CommentInput({
+  register,
+  contentLength = 0,
+  disabled,
+  variant = 'create',
+}: CommentInputProps) {
+  const isOverLimit = contentLength >= 500;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-1 items-center rounded-xl border bg-white px-3 py-3 md:rounded-2xl md:px-4 md:py-4',
+        isOverLimit
+          ? 'border-red-400 bg-red-50'
+          : variant === 'edit'
+            ? 'border-orange-500'
+            : 'border-gray-300',
+      )}
+    >
+      <input
+        {...register}
+        type="text"
+        disabled={disabled}
+        placeholder="댓글을 입력해주세요"
+        maxLength={500}
+        aria-label="댓글 입력"
+        className={cn(
+          'flex-1 pr-3 outline-none placeholder:text-gray-500 disabled:bg-transparent',
+          variant === 'create' ? 'font-base-regular text-gray-500' : 'font-sm-regular text-black',
+        )}
+      />
+      <span className="font-xs-regular shrink-0 text-gray-500">{contentLength}/500</span>
+    </div>
+  );
+}

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -42,8 +42,8 @@ export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: Comm
   );
 
   const kebabItems = [
-    { label: '삭제하기', onClick: () => setDeleteDialogOpen(true), variant: 'danger' as const },
     { label: '수정하기', onClick: () => setIsEditing(true) },
+    { label: '삭제하기', onClick: () => setDeleteDialogOpen(true), variant: 'danger' as const },
   ];
 
   const onSubmit = ({ content }: CommentForm) => {
@@ -107,7 +107,7 @@ export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: Comm
               </button>
               <button
                 type="submit"
-                disabled={isUpdating}
+                disabled={!contentValue?.trim() || contentValue === content || isUpdating}
                 className="font-sm-semibold w-16 rounded-full bg-orange-500 px-[18px] py-[10px] text-white disabled:cursor-not-allowed disabled:opacity-50"
               >
                 수정

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import type { Comment } from '../../types';
+import type { CommentForm } from './CommentInput';
 
 import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
 import { formatRelativeTime } from '@/utils/formatRelativeTime';
@@ -10,7 +13,9 @@ import { formatRelativeTime } from '@/utils/formatRelativeTime';
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
 
+import { useUpdateComment } from '../../_api/communityQueries';
 import { WriterAvatar } from '../../_components/WriterAvatar';
+import { CommentInput, commentSchema } from './CommentInput';
 
 interface CommentItemProps {
   comment: Comment;
@@ -22,10 +27,34 @@ interface CommentItemProps {
 export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: CommentItemProps) {
   const { content, createdAt, writer } = comment;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const { register, handleSubmit, reset, watch } = useForm<CommentForm>({
+    resolver: zodResolver(commentSchema),
+    defaultValues: { content },
+  });
+
+  const contentValue = watch('content');
+
+  const { mutate: updateComment, isPending: isUpdating } = useUpdateComment(
+    comment.postId,
+    comment.id,
+  );
 
   const kebabItems = [
     { label: '삭제하기', onClick: () => setDeleteDialogOpen(true), variant: 'danger' as const },
+    { label: '수정하기', onClick: () => setIsEditing(true) },
   ];
+
+  const onSubmit = ({ content }: CommentForm) => {
+    updateComment(content, {
+      onSuccess: () => {
+        reset();
+        setIsEditing(false);
+      },
+      onError: () => toast.error('댓글 수정에 실패했습니다.'),
+    });
+  };
 
   return (
     <li className="flex flex-col gap-3">
@@ -53,12 +82,47 @@ export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: Comm
         {isMyComment && <KebabMenu items={kebabItems} disabled={isDeleting} />}
       </div>
 
-      <div className="flex flex-col gap-2">
-        <p className="font-sm-regular md:font-base-regular text-gray-700">{content}</p>
-        <span className="font-xs-regular md:font-sm-regular text-gray-400">
-          {formatRelativeTime(createdAt)}
-        </span>
-      </div>
+      {isEditing ? (
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2">
+          <CommentInput
+            register={register('content')}
+            contentLength={contentValue?.length ?? 0}
+            variant="edit"
+          />
+          <div className="flex items-center justify-between">
+            <span className="font-xs-regular md:font-sm-regular text-gray-400">
+              {formatRelativeTime(createdAt)}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setIsEditing(false);
+                  reset();
+                }}
+                disabled={isUpdating}
+                className="font-sm-semibold w-16 rounded-full border border-gray-300 px-[18px] py-[10px] text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                type="submit"
+                disabled={isUpdating}
+                className="font-sm-semibold w-16 rounded-full bg-orange-500 px-[18px] py-[10px] text-white disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                수정
+              </button>
+            </div>
+          </div>
+        </form>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <p className="font-sm-regular md:font-base-regular text-gray-700">{content}</p>
+          <span className="font-xs-regular md:font-sm-regular text-gray-400">
+            {formatRelativeTime(createdAt)}
+          </span>
+        </div>
+      )}
     </li>
   );
 }

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -1,23 +1,17 @@
 'use client';
 
 import type { Comment } from '../../types';
+import type { CommentForm } from './CommentInput';
 
 import { useEffect, useMemo } from 'react';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { cn } from '@/lib';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
-import z from 'zod';
 
 import { useCreateComment, useDeleteComment, useGetComments } from '../../_api/communityQueries';
+import { CommentInput, commentSchema } from './CommentInput';
 import { CommentItem } from './CommentItem';
-
-const schema = z.object({
-  content: z.string().min(1, '댓글을 입력해주세요.').max(500, '500자 이내로 입력해주세요'),
-});
-
-type CommentForm = z.infer<typeof schema>;
 
 interface CommentSectionProps {
   postId: number;
@@ -55,7 +49,7 @@ export function CommentSection({
   const isBusy = isPostDeleting || isFetching;
 
   const { register, handleSubmit, reset, watch } = useForm<CommentForm>({
-    resolver: zodResolver(schema),
+    resolver: zodResolver(commentSchema),
     defaultValues: { content: '' },
   });
 
@@ -86,23 +80,7 @@ export function CommentSection({
       </div>
 
       <div className="flex gap-3 md:gap-4">
-        <div
-          className={cn(
-            'flex flex-1 items-center justify-between rounded-xl border px-3 py-3 md:rounded-2xl md:px-4 md:py-4',
-            contentValue?.length >= 500 ? 'border-red-400 bg-red-50' : 'border-gray-300',
-          )}
-        >
-          <input
-            {...register('content')}
-            type="text"
-            disabled={isBusy}
-            placeholder="댓글을 입력해주세요"
-            maxLength={500}
-            aria-label="댓글 입력"
-            className="font-sm-regular md:font-base-regular flex-1 pr-3 text-gray-700 outline-none placeholder:text-gray-500 disabled:bg-gray-50"
-          />
-          <span className="font-xs-regular text-gray-500">{contentValue?.length}/500</span>
-        </div>
+        <CommentInput register={register('content')} contentLength={contentValue?.length ?? 0} />
         <button
           type="button"
           onClick={handleSubmit(onSubmit)}

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -141,6 +141,23 @@ export const useGetComments = (postId: number) => {
   });
 };
 
+// 댓글 수정
+export const useUpdateComment = (postId: number, commentId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (content: string) =>
+      apiClient<Comment>(`/posts/${postId}/comments/${commentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communityQueryKeys.comments(postId) });
+    },
+  });
+};
+
 // 댓글 삭제
 export const useDeleteComment = (postId: number) => {
   const queryClient = useQueryClient();


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #298  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 댓글 아이템에 수정 모드 UI 추가
- 댓글 수정 API 연동
- 수정 모드 진입 시 기존 댓글 내용이 채워진 인풋으로 전환
- 작성/수정 폼 공통 컴포넌트 분리

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 댓글 인풋을 CommentInput 공통 컴포넌트로 분리해 작성/수정 폼 간 일관성 유지
- variant prop으로 작성과 수정 스타일 분기
- zod schema와 CommentForm 타입을 CommentInput에서 export해 두 폼에서 재사용

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)
<img width="886" height="752" alt="스크린샷 2026-04-07 오후 5 15 59" src="https://github.com/user-attachments/assets/57373dab-1367-4d0a-852e-d7efa62c0c06" />

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 게시물 상세 페이지 접속
2. 본인이 작성한 댓글의 케밥 메뉴 클릭
3. '수정하기' 선택
4. 기존 댓글 내용이 인풋에 채워지는지 확인
5. 내용 수정 후 '수정' 버튼 클릭
6. 수정된 내용으로 반영되는지 확인
7. '취소' 버튼 클릭 시 원래 내용으로 돌아오는지 확인
8. 500자 입력 시 인풋 테두리가 빨간색으로 변경되는지 확인
```

**예상 결과:**

- 수정 모드 진입 시 기존 댓글 내용이 인풋에 표시됨
- 수정 성공 시 변경된 내용으로 즉시 반영됨
- 취소 시 원본 내용 유지
- 500자 도달 시 빨간 테두리로 시각적 피드백 제공

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 자신의 댓글을 인라인으로 편집(편집/취소/저장)할 수 있습니다.
  * 댓글 입력에 한국어 유효성 검사 메시지와 함께 최대 500자 제한이 적용됩니다.
  * 입력창에 실시간 문자 수 카운터와 제한 도달 시 시각적 표시가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->