### PR TITLE
Feat/312 impl hoc error fallback

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,35 +1,25 @@
 import type { NextConfig } from 'next';
 
+import { getImageRemotePatterns } from '@/config/remote-images';
 import { getLocalSubnetList } from '@/lib/network';
 
 import { version } from './package.json';
+
+const isProduction = process.env.NODE_ENV === 'production';
 
 const nextConfig: NextConfig = {
   /* config options here */
   env: {
     NEXT_PUBLIC_APP_VERSION: version,
   },
+  compiler: {
+    // Production 에서만 console 제거(console.error는 제외), development 에서는 모두 출력
+    removeConsole: isProduction ? { exclude: ['error'] } : false,
+  },
   // 호스트명만 (프로토콜·포트 필요 없음). `https://*.…` 는 내부 와일드카드 매칭이 깨짐.
-  allowedDevOrigins: [
-    '*.ngrok-free.app',
-    '127.0.0.1',
-    ...getLocalSubnetList(),
-    // ...(process.env.ALLOWED_DEV_ORIGINS?.split(',')
-    //   .map((s) => s.trim())
-    //   .filter(Boolean) ?? []),
-  ],
+  allowedDevOrigins: ['127.0.0.1', '*.ngrok-free.dev', '*.ngrok-free.app', ...getLocalSubnetList()],
   images: {
-    remotePatterns: [
-      { protocol: 'https', hostname: 'placehold.co' },
-      { protocol: 'https', hostname: '*.googleusercontent.com' },
-      { protocol: 'https', hostname: '*.kakaocdn.net' },
-      { protocol: 'http', hostname: '*.kakaocdn.net' },
-      {
-        protocol: 'https',
-        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
-        pathname: '/slid-todo/**',
-      },
-    ],
+    remotePatterns: getImageRemotePatterns(),
   },
 };
 

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,24 +1,108 @@
-interface ErrorFallbackProps {
+import type { ComponentType } from 'react';
+
+import { cn } from '@/lib/shadcn';
+
+export type ErrorFallbackVariant = 'full' | 'embedded' | 'compact';
+
+export interface ErrorFallbackProps {
   onRetry: () => void;
-  title: string;
+  title?: string;
+  /** full: 페이지급(기본), embedded: 섹션/탭, compact: 카드·위젯 */
+  variant?: ErrorFallbackVariant;
+  className?: string;
 }
 
-export function ErrorFallback({ onRetry, title }: ErrorFallbackProps) {
+const variantClassNames: Record<
+  ErrorFallbackVariant,
+  { root: string; title: string; body: string; message: string; button: string }
+> = {
+  full: {
+    root: 'h-full w-full bg-gray-100 px-4 py-6 md:px-8 md:py-12',
+    title: 'font-xl-semibold md:font-2xl-semibold mb-6 px-2 text-black md:mb-8',
+    body: 'flex flex-col items-center gap-4 py-40',
+    message: 'font-3xl-regular mb-4 text-gray-600',
+    button: 'font-sm-medium rounded-xl bg-orange-500 px-5 py-2.5 text-white',
+  },
+  embedded: {
+    root: 'flex h-full min-h-[12rem] w-full min-w-0 flex-col bg-gray-100 px-4 py-4 md:px-6 md:py-6',
+    title: 'font-lg-semibold md:font-xl-semibold mb-3 shrink-0 px-1 text-black md:mb-4',
+    body: 'flex min-h-0 flex-1 flex-col items-center justify-center gap-3 py-8 md:py-12',
+    message: 'font-xl-regular text-center text-gray-600',
+    button: 'font-sm-medium rounded-xl bg-orange-500 px-5 py-2.5 text-white',
+  },
+  compact: {
+    root: 'flex h-full min-h-0 w-full min-w-0 flex-col items-center justify-center gap-2 rounded-lg bg-gray-100 px-3 py-5',
+    title: 'font-sm-semibold mb-0.5 text-center text-gray-800',
+    body: 'flex flex-col items-center gap-2',
+    message: 'font-base-regular text-center text-gray-600',
+    button: 'font-xs-medium rounded-lg bg-orange-500 px-4 py-2 text-white',
+  },
+};
+
+/**
+ * @description 각 variant 별 스타일이 적용됨
+ * @param onRetry - 다시 시도하기 버튼 클릭 시 호출되는 함수
+ * @param title - 에러 메시지 제목
+ * @param variant - full: 페이지급(기본), embedded: 섹션/탭, compact: 카드·위젯
+ * @param className - 에러 메시지 컴포넌트 클래스
+ * @returns ErrorFallback 컴포넌트
+ */
+export function ErrorFallback({ onRetry, title, variant = 'full', className }: ErrorFallbackProps) {
+  const v = variantClassNames[variant];
+
   return (
-    <div className="h-full w-full bg-gray-100 px-4 py-6 md:px-8 md:py-12">
-      <h1 className="font-xl-semibold md:font-2xl-semibold mb-6 px-2 text-black md:mb-8">
-        {title}
-      </h1>
-      <div className="flex flex-col items-center gap-4 py-40">
-        <p className="font-3xl-regular mb-4 text-gray-600">데이터를 불러오지 못했어요.</p>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="font-sm-medium rounded-xl bg-orange-500 px-5 py-2.5 text-white"
-        >
+    <div className={cn(v.root, className)}>
+      <h1 className={cn(v.title, title ? 'block' : 'hidden')}>{title}</h1>
+      <div className={v.body}>
+        <p className={v.message}>데이터를 불러오지 못했어요.</p>
+        <button type="button" onClick={onRetry} className={v.button}>
           다시 시도하기
         </button>
       </div>
     </div>
   );
+}
+
+/** HOC: `isError` / `onRetry`가 props로 전달될 때 분기 로직을 공통화 */
+export type WithErrorFallbackProps = {
+  isError: boolean;
+  onRetry: () => void;
+};
+
+/**
+ *
+ * @param Component - 에러 메시지를 표시할 컴포넌트
+ * @param options - 에러 메시지 컴포넌트 옵션
+ * @param options.title - 에러 메시지 제목
+ * @param options.variant - 에러 메시지 컴포넌트 변형
+ * @param options.className - 에러 메시지 컴포넌트 클래스
+ * @returns
+ */
+export function withErrorFallback<P extends object>(
+  Component: ComponentType<P>,
+  options: {
+    title?: string;
+    variant?: ErrorFallbackVariant;
+    className?: string;
+  },
+): ComponentType<P & WithErrorFallbackProps> {
+  function WithErrorFallback(props: P & WithErrorFallbackProps) {
+    const { isError, onRetry, ...rest } = props;
+    if (isError) {
+      return (
+        <ErrorFallback
+          onRetry={onRetry}
+          title={options.title ?? '알 수 없는 오류'}
+          variant={options.variant ?? 'full'}
+          className={options.className}
+        />
+      );
+    }
+    return <Component {...(rest as P)} />;
+  }
+
+  const name = Component.displayName ?? Component.name ?? 'Component';
+  WithErrorFallback.displayName = `withErrorFallback(${name})`;
+
+  return WithErrorFallback;
 }

--- a/src/config/remote-images.ts
+++ b/src/config/remote-images.ts
@@ -1,0 +1,87 @@
+/**
+ * next/image `images.remotePatterns` 항목과 동일한 형태(구조적 호환).
+ * @see https://nextjs.org/docs/app/api-reference/components/image#remotepatterns
+ */
+export type ImageRemotePattern = {
+  protocol?: 'http' | 'https';
+  hostname: string;
+  port?: string;
+  pathname?: string;
+  search?: string;
+};
+
+/**
+ * next/image `remotePatterns`용 출처 목록.
+ * 형식: `{protocol}://{hostname}[/pathname]`
+ * - hostname: 리터럴 또는 `*.example.com` 와일드카드
+ * - pathname: 생략 시 모든 경로 허용. 필요 시 `/prefix/**` 등으로 제한
+ */
+export const REMOTE_IMAGE_SOURCES = [
+  'https://placehold.co',
+  'https://*.googleusercontent.com',
+  'https://*.kakaocdn.net',
+  'http://*.kakaocdn.net',
+  'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/slid-todo/**',
+] as const;
+
+export type RemoteImageSource = (typeof REMOTE_IMAGE_SOURCES)[number];
+
+/**
+ * 단일 출처 문자열을 `ImageRemotePattern`으로 변환한다.
+ * @throws 프로토콜이 없거나 비어 있는 경우
+ */
+export function remoteImageSourceToPattern(source: string): ImageRemotePattern {
+  const trimmed = source.trim();
+  const protoMatch = /^(https?):\/\//i.exec(trimmed);
+  if (!protoMatch) {
+    throw new Error(`Invalid remote image source (expected protocol://…): ${source}`);
+  }
+
+  const protocol = protoMatch[1].toLowerCase() as 'http' | 'https';
+  const rest = trimmed.slice(protoMatch[0].length);
+  const withoutHashQuery = rest.split('?')[0]?.split('#')[0] ?? rest;
+  const slashIdx = withoutHashQuery.indexOf('/');
+
+  const authority = slashIdx === -1 ? withoutHashQuery : withoutHashQuery.slice(0, slashIdx);
+  const rawPathname = slashIdx === -1 ? undefined : withoutHashQuery.slice(slashIdx);
+
+  const { hostname, port } = splitHostPort(authority);
+
+  const pattern: ImageRemotePattern = { protocol, hostname };
+  if (port !== undefined) {
+    pattern.port = port;
+  }
+  if (rawPathname !== undefined && rawPathname !== '' && rawPathname !== '/') {
+    pattern.pathname = rawPathname;
+  }
+
+  return pattern;
+}
+
+function splitHostPort(authority: string): { hostname: string; port?: string } {
+  if (authority.startsWith('[')) {
+    const end = authority.indexOf(']');
+    if (end !== -1 && authority[end + 1] === ':') {
+      return {
+        hostname: authority.slice(0, end + 1),
+        port: authority.slice(end + 2),
+      };
+    }
+    return { hostname: authority };
+  }
+
+  const colonIdx = authority.lastIndexOf(':');
+  if (colonIdx > 0 && /^[0-9]+$/.test(authority.slice(colonIdx + 1))) {
+    return {
+      hostname: authority.slice(0, colonIdx),
+      port: authority.slice(colonIdx + 1),
+    };
+  }
+
+  return { hostname: authority };
+}
+
+/** `REMOTE_IMAGE_SOURCES` 전체를 `images.remotePatterns`에 넘길 배열로 변환한다. */
+export function getImageRemotePatterns(): ImageRemotePattern[] {
+  return REMOTE_IMAGE_SOURCES.map((src) => remoteImageSourceToPattern(src));
+}

--- a/src/config/remote-images.ts
+++ b/src/config/remote-images.ts
@@ -47,10 +47,7 @@ export function remoteImageSourceToPattern(source: string): ImageRemotePattern {
 
   const { hostname, port } = splitHostPort(authority);
 
-  const pattern: ImageRemotePattern = { protocol, hostname };
-  if (port !== undefined) {
-    pattern.port = port;
-  }
+  const pattern: ImageRemotePattern = { protocol, hostname, port: port ?? '' };
   if (rawPathname !== undefined && rawPathname !== '' && rawPathname !== '/') {
     pattern.pathname = rawPathname;
   }


### PR DESCRIPTION
# 📋 PR 개요

> 에러 UI를 **variant·HOC로 재사용**하고, **이미지 remote 패턴을 설정 모듈로 분리**하며, **프로덕션에서 console 정리·dev origin/ngrok**을 정돈함

- **관련 이슈:** Closes #312  <!-- 번호 틀리면 수정 -->
- **PR 유형:**
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [x] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

**What**

- **`ErrorFallback`**
  - `variant`: `full` | `embedded` | `compact` — 페이지·섹션·위젯 등 레이아웃에 맞는 스타일 분기.
  - `title` optional, `className`으로 래퍼 확장; `cn`으로 클래스 합성.
  - **`withErrorFallback(Component, options)` HOC**: `isError` / `onRetry` props로 공통 분기 (`displayName` 설정).
- **`src/config/remote-images.ts` (신규)**
  - `REMOTE_IMAGE_SOURCES` 문자열 목록 → `getImageRemotePatterns()`로 `next/image` `remotePatterns`와 동형 객체 배열 생성 (`remoteImageSourceToPattern` 파서 포함).

- **`next.config.ts`**
  - `images.remotePatterns`를 `getImageRemotePatterns()`로 위임.
  - `compiler.removeConsole`: **production만** 활성, **`console.error`는 유지**.
  - `allowedDevOrigins`: `*.ngrok-free.dev` 추가, 주석 처리된 env 확장 코드 제거, `127.0.0.1`·ngrok·로컬 서브넷 유지.

**Why**

- 섹션/카드 단위에서도 동일한 에러 UX를 쓰되 **한 컴포넌트·한 HOC**로 맞추려고 variant + HOC를 도입.
- 이미지 허용 도메인을 **한곳(URL 문자열)** 에 모아 두면 추가/리뷰가 쉽고, Next 설정 파일은 얇게 유지.
- 프로덕션 빌드에서 **불필요한 로그 제거**하되 **에러 추적용 `console.error`는 남김**.

**대안**

- 에러 분기만 각 페이지에서 `if (isError)` 반복 (거부: HOC로 중복 제거).
- `remotePatterns`를 계속 `next.config`에 인라인 나열 (거부: 출처 목록 단일화).

---

## ✅ 체크리스트

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
|  |  |


---

## 🧪 테스트 방법

```text
1. pnpm dev 로 기동 후, ErrorFallback을 쓰는 화면에서 의도적으로 API 실패(또는 MSW/네트워크 끊김) 유도
2. 동일 화면에서 variant를 full / embedded / compact로 바꿔 레이아웃·타이포가 기대대로인지 확인
3. withErrorFallback으로 감싼 컴포넌트에서 isError true/false 전환 시 본문 vs 폴백 전환 확인
4. next/image로 REMOTE_IMAGE_SOURCES에 있는 도메인 이미지가 로드되는지 확인
5. NODE_ENV=production 빌드(pnpm build) 후 브라우저에서 console.log 제거·console.error 유무 확인
```

**예상 결과:**

- 에러 시 variant에 맞는 폴백 UI, 재시도 버튼 동작.
- 외부 이미지 도메인 기존과 동등하게 허용.
- 프로덕션 번들에서 일반 console 제거, error 로그는 남음.

---

## ⚠️ 리뷰어 참고사항

- `ErrorFallback`의 `title`이 없으면 `h1`은 `hidden` 처리 — 스크린리더/시맨틱 측면에서 필요하면 `aria` 보강 논의 가능.
- `withErrorFallback` 기본 제목은 `'알 수 없는 오류'` — 문구 확정 시 옵션/상수로 빼도 됨.
- `allowedDevOrigins`에서 env 기반 확장 주석 블록이 제거됨 — 팀에서 다시 쓸 계획이 있으면 별도 이슈로 복구 검토.
- HOC 패턴을 사용할 방법에 대해서는 아래 참고 자료에 사용 매뉴얼을 참고해주세요.

---

## 📎 참고 자료

- #314 
- [Next.js Image `remotePatterns`](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns)
- [Next.js Compiler `removeConsole`](https://nextjs.org/docs/app/api-reference/config/next-config-js/compiler#removeconsole)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 에러 폴백 컴포넌트에 다양한 표시 방식(전체, 임베디드, 콤팩트) 옵션 추가
  * 에러 처리용 고차 컴포넌트 API 추가

* **최적화**
  * 프로덕션 환경에서 콘솔 출력 자동 제거 (오류 메시지는 유지)
  * 원격 이미지 소스 설정 관리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->