### PR TITLE
:sparkles: features: Notes 조회페이지 무한스크롤 적용

### DIFF
--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -1,6 +1,6 @@
 import type { PaginatedResponse } from '@/api/response';
 import type { Todo } from '@/api/todos';
-import type { QueryClient } from '@tanstack/react-query';
+import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 
 import { GOALS } from '@/api/goals';
 import { TODOS } from '@/api/todos';
@@ -129,48 +129,21 @@ export const NOTE = 'NOTE';
 export const NOTES = 'NOTES';
 export const NOTES_URL = '/notes';
 
-interface GetNotesParams {
-  todoId?: number;
-  goalId?: number;
-  cursor?: number;
-  limit?: number;
-}
-
 export type NotesGetResponse = PaginatedResponse<Notes, 'notes'>;
 type CreateNotePayload = Pick<Notes, 'todoId' | 'title'> &
   Partial<Pick<Notes, 'content' | 'linkUrl'>>;
 
 type PatchNotePayload = Pick<Notes, 'id'> & Partial<Pick<Notes, 'title' | 'content' | 'linkUrl'>>;
-export const useGetNotes = ({ todoId, goalId, cursor, limit }: GetNotesParams = {}) => {
-  return useQuery({
-    queryKey: [NOTES, { todoId, goalId, cursor, limit }],
-    queryFn: async () => {
-      const params = new URLSearchParams();
-      if (todoId !== undefined) params.append('todoId', String(todoId));
-      if (goalId !== undefined) params.append('goalId', String(goalId));
-      if (cursor !== undefined) params.append('cursor', String(cursor));
-      if (limit !== undefined) params.append('limit', String(limit));
-
-      const queryString = params.toString();
-      const url = queryString ? `${NOTES_URL}?${queryString}` : NOTES_URL;
-
-      return await apiClient<NotesGetResponse>(url);
-    },
-    enabled: !!goalId,
-  });
-};
 
 export const useGetNotesInfinite = ({ goalId, limit = 5 }: { goalId: number; limit?: number }) => {
   return useInfiniteQuery({
     queryKey: [NOTES, { goalId, limit }],
-    queryFn: async ({ pageParam }) => {
-      const res = await apiClient<NotesGetResponse>(
+    queryFn: async ({ pageParam }) =>
+      await apiClient<NotesGetResponse>(
         `${NOTES_URL}?goalId=${goalId}&limit=${limit}${pageParam ? `&cursor=${pageParam}` : ''}`,
-      );
-      return res;
-    },
+      ),
     initialPageParam: null as number | null,
-    getNextPageParam: (lastPage) => lastPage?.nextCursor ?? null, // ← ?. 추가
+    getNextPageParam: (lastPage) => lastPage?.nextCursor ?? null,
     placeholderData: keepPreviousData,
   });
 };
@@ -184,6 +157,7 @@ export const useGetNote = ({ id }: { id: number }) => {
     enabled: !!id,
   });
 };
+
 export const usePostNote = (options: { onSuccess?: () => void }) => {
   const queryClient: QueryClient = useQueryClient();
   return useMutation({
@@ -202,26 +176,37 @@ export const usePostNote = (options: { onSuccess?: () => void }) => {
       const previousNotes = queryClient.getQueriesData({ queryKey: [NOTES] });
 
       // 낙관적으로 캐시에 추가
-      queryClient.setQueriesData({ queryKey: [NOTES] }, (old: NotesGetResponse | undefined) => {
-        if (!old) return old;
-        const optimisticNote: Notes = {
-          id: Date.now(), // 임시 id
-          title: payload.title,
-          content: payload.content ?? { type: 'doc', content: [] },
-          linkUrl: payload.linkUrl ?? '',
-          todoId: payload.todoId,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          teamId: '',
-          userId: 0,
-          todo: { id: payload.todoId, title: '', done: false },
-        };
-        return {
-          ...old,
-          notes: [optimisticNote, ...old.notes],
-          totalCount: old.totalCount + 1,
-        };
-      });
+      queryClient.setQueriesData(
+        { queryKey: [NOTES] },
+        (old: InfiniteData<NotesGetResponse> | undefined) => {
+          if (!old) return old;
+          const optimisticNote: Notes = {
+            id: Date.now(), // 임시 id
+            title: payload.title,
+            content: payload.content ?? { type: 'doc', content: [] },
+            linkUrl: payload.linkUrl ?? '',
+            todoId: payload.todoId,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            teamId: '',
+            userId: 0,
+            todo: { id: payload.todoId, title: '', done: false },
+          };
+
+          return {
+            ...old,
+            pages: old.pages.map((page: NotesGetResponse, index: number) =>
+              index === 0
+                ? {
+                    ...page,
+                    notes: [optimisticNote, ...page.notes],
+                    totalCount: page.totalCount + 1,
+                  }
+                : page,
+            ),
+          };
+        },
+      );
 
       return { previousNotes };
     },
@@ -275,12 +260,15 @@ export const useDeleteNote = () => {
       const previousTodos = queryClient.getQueriesData({ queryKey: [NOTES] });
       queryClient.setQueriesData(
         { queryKey: [NOTES] },
-        (old: PaginatedResponse<Notes, 'notes'>) => {
+        (old: InfiniteData<NotesGetResponse> | undefined) => {
           if (!old) return old;
+
           return {
             ...old,
-            notes: old.notes.filter((note: Notes) => note.id !== id),
-            totalCount: old.totalCount - 1,
+            pages: old.pages.map((page: NotesGetResponse) => ({
+              ...page,
+              notes: page.notes.filter((note: Notes) => note.id !== id),
+            })),
           };
         },
       );
@@ -292,7 +280,9 @@ export const useDeleteNote = () => {
       });
     },
     onSettled: (_, __, payload) => {
-      queryClient.invalidateQueries({ queryKey: [NOTES, GOALS, TODOS] });
+      queryClient.invalidateQueries({ queryKey: [NOTES] });
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
+      queryClient.invalidateQueries({ queryKey: [TODOS] });
       queryClient.invalidateQueries({ queryKey: [NOTE, payload.id] });
     },
   });

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -5,7 +5,13 @@ import type { QueryClient } from '@tanstack/react-query';
 import { GOALS } from '@/api/goals';
 import { TODOS } from '@/api/todos';
 import { apiClient } from '@/lib/apiClient.browser';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 // ── 마크(인라인 스타일) ──────────────────────────
 type BoldMark = { type: 'bold' };
@@ -151,6 +157,21 @@ export const useGetNotes = ({ todoId, goalId, cursor, limit }: GetNotesParams = 
       return await apiClient<NotesGetResponse>(url);
     },
     enabled: !!goalId,
+  });
+};
+
+export const useGetNotesInfinite = ({ goalId, limit = 5 }: { goalId: number; limit?: number }) => {
+  return useInfiniteQuery({
+    queryKey: [NOTES, { goalId, limit }],
+    queryFn: async ({ pageParam }) => {
+      const res = await apiClient<NotesGetResponse>(
+        `${NOTES_URL}?goalId=${goalId}&limit=${limit}${pageParam ? `&cursor=${pageParam}` : ''}`,
+      );
+      return res;
+    },
+    initialPageParam: null as number | null,
+    getNextPageParam: (lastPage) => lastPage?.nextCursor ?? null, // ← ?. 추가
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteList.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteList.tsx
@@ -10,39 +10,40 @@ interface NoteListProps {
   notes: Notes[];
   goalId: number;
   observerRef: Ref<HTMLDivElement>;
+  hasNextPage: boolean;
 }
 
-export default function NoteList({ notes, goalId, observerRef }: NoteListProps) {
-  if (notes.length === 0) {
-    return (
-      <div className="flex min-h-[60vh] w-full items-center justify-center">
-        <div className="flex h-fit w-fit flex-col items-center space-y-4">
-          <Image
-            width={131}
-            height={140}
-            src={emptyImage}
-            alt="describe empty note situation"
-            className="h-22.5 w-20 object-contain md:h-35 md:w-32.5"
-          />
-          <p className="font-base-regular text-gray-400">아직 등록된 노트가 없어요</p>
-        </div>
-      </div>
-    );
-  }
-
+export default function NoteList({ notes, goalId, observerRef, hasNextPage }: NoteListProps) {
   return (
-    <div className="grid w-full grid-cols-1 gap-4 pb-10 lg:grid-cols-2">
-      {notes.map((note: Notes) => (
-        <NoteCard
-          key={note.id}
-          goalId={goalId}
-          id={note.id}
-          title={note.title}
-          todo={note.todo}
-          createdAt={note.createdAt}
-        />
-      ))}
-      <div ref={observerRef} className="h-1"></div>
-    </div>
+    <>
+      {notes.length === 0 ? (
+        <div className="flex min-h-[60vh] w-full items-center justify-center">
+          <div className="flex h-fit w-fit flex-col items-center space-y-4">
+            <Image
+              width={131}
+              height={140}
+              src={emptyImage}
+              alt="describe empty note situation"
+              className="h-22.5 w-20 object-contain md:h-35 md:w-32.5"
+            />
+            <p className="font-base-regular text-gray-400">아직 등록된 노트가 없어요</p>
+          </div>
+        </div>
+      ) : (
+        <div className="grid w-full grid-cols-1 gap-4 pb-10 lg:grid-cols-2">
+          {notes.map((note: Notes) => (
+            <NoteCard
+              key={note.id}
+              goalId={goalId}
+              id={note.id}
+              title={note.title}
+              todo={note.todo}
+              createdAt={note.createdAt}
+            />
+          ))}
+        </div>
+      )}
+      {hasNextPage && <div ref={observerRef} className="h-1" />}
+    </>
   );
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteList.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteList.tsx
@@ -1,4 +1,5 @@
 import type { Notes } from '@/api/notes';
+import type { Ref } from 'react';
 
 import Image from 'next/image';
 import emptyImage from '@/../public/images/big-zero-done.svg';
@@ -8,9 +9,10 @@ import NoteCard from './NoteCard';
 interface NoteListProps {
   notes: Notes[];
   goalId: number;
+  observerRef: Ref<HTMLDivElement>;
 }
 
-export default function NoteList({ notes, goalId }: NoteListProps) {
+export default function NoteList({ notes, goalId, observerRef }: NoteListProps) {
   if (notes.length === 0) {
     return (
       <div className="flex min-h-[60vh] w-full items-center justify-center">
@@ -40,6 +42,7 @@ export default function NoteList({ notes, goalId }: NoteListProps) {
           createdAt={note.createdAt}
         />
       ))}
+      <div ref={observerRef} className="h-1"></div>
     </div>
   );
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NotesContainer.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NotesContainer.tsx
@@ -7,10 +7,11 @@ import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import goalImage from '@/../public/images/large-goal.svg';
 import { useGetGoal } from '@/api/goals';
-import { useGetNotes } from '@/api/notes';
+import { useGetNotesInfinite } from '@/api/notes';
 import NotesContainerSkeleton from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteContainerSkeleton';
 import NoteList from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteList';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import { SearchInput } from '@/components/common/SearchInput';
 import { SortFilter } from '@/components/common/SortFilter';
@@ -18,16 +19,25 @@ import { SortFilter } from '@/components/common/SortFilter';
 export default function NotesContainer() {
   const pathname = usePathname();
   const goalId: number = Number(pathname.split('/')[2]);
-  const { data, isLoading, isSuccess } = useGetNotes({ goalId });
+
   const { data: goalData } = useGetGoal({ id: goalId });
+  const { data, isLoading, isSuccess, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetNotesInfinite({ goalId });
+  const allNotes = data?.pages.flatMap((page) => page.notes) ?? [];
 
   const [searchValue, setSearchValue] = useState('');
   const debouncedSearch = useDebouncedValue(searchValue, 300);
 
   // 클라이언트 필터링
-  const filteredNotes = data?.notes.filter((note: Notes) =>
+  const filteredNotes: Notes[] = allNotes.filter((note: Notes) =>
     note.title.toLowerCase().includes(debouncedSearch.toLowerCase()),
   );
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   if (isLoading) return <NotesContainerSkeleton />;
   if (isSuccess)
@@ -65,7 +75,7 @@ export default function NotesContainer() {
 
         {/* 노트 리스트 */}
         <div className="mt-4 md:mt-6">
-          <NoteList notes={filteredNotes ?? []} goalId={goalId} />
+          <NoteList notes={filteredNotes ?? []} goalId={goalId} observerRef={observerRef} />
         </div>
       </>
     );

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NotesContainer.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NotesContainer.tsx
@@ -75,7 +75,12 @@ export default function NotesContainer() {
 
         {/* 노트 리스트 */}
         <div className="mt-4 md:mt-6">
-          <NoteList notes={filteredNotes ?? []} goalId={goalId} observerRef={observerRef} />
+          <NoteList
+            notes={filteredNotes ?? []}
+            goalId={goalId}
+            observerRef={observerRef}
+            hasNextPage={hasNextPage}
+          />
         </div>
       </>
     );


### PR DESCRIPTION
# 📋 PR 개요

노트 모아보기 페이지에서 전체 노트를 한 번에 불러오는 방식에서 무한스크롤 방식으로 변경합니다.

- **관련 이슈:** Closes #260 
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?

- `useGetNotesInfinite` 훅 추가 — `useInfiniteQuery` 기반 cursor 페이지네이션
- `NotesContainer`에서 `useGetNotes` → `useGetNotesInfinite`로 교체
- `useInfiniteScroll` 훅 + `IntersectionObserver`로 스크롤 끝 감지
- `NoteList` 하단에 `observerRef` 연결 타겟 추가
- 클라이언트 검색 필터링을 `allNotes` (누적 전체) 기준으로 변경
- 
**Why:**
- 기존 `useGetNotes`는 단일 페이지만 반환하여 대량 노트 조회 시 성능 문제 발생 가능
- `useQuery` + `useState` + `useEffect` 조합으로 cursor 누적 시 `setState` 캐스케이딩 문제 발생 → `useInfiniteQuery`로 해결
- `queryKey`에 `'infinite'` 네임스페이스를 추가하여 기존 `useGetNotes` 캐시와 충돌 방지

**대안:**
- `useQuery` + `useRef(Map)` 패턴으로 누적 관리 가능하나, TanStack Query가 제공하는 `pages[]` 구조를 활용하는 것이 더 명확하고 유지보수에 유리하다고 판단


---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [x] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [x] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [x] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 노트가 5개 이상 등록된 목표 페이지로 이동
2. 목표 상세 → 노트 모아보기 진입
3. 노트 리스트 하단까지 스크롤
4. 추가 노트가 자동으로 로드되는지 확인
5. 검색어 입력 시 누적된 전체 노트 기준으로 필터링되는지 확인
```

**예상 결과:**
- 초기 5개 노트 표시 후 스크롤 시 추가 노트 로드
- `nextCursor`가 `null`이면 더 이상 요청하지 않음
- 검색 필터가 현재 페이지가 아닌 누적 전체 노트에 적용됨

---

## ⚠️ 리뷰어 참고사항
- 검색 필터링은 클라이언트 사이드로, 스크롤 전 로드되지 않은 노트는 검색 결과에 포함되지 않습니다. 추후 서버 검색 API 연동 시 개선 예정입니다.
- `queryKey`에 `'infinite'` 네임스페이스 추가로 기존 `useGetNotes` 캐시와 분리했습니다.

---

## 📎 참고 자료
- [TanStack Query — useInfiniteQuery](https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery)
- [MDN — IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 노트에 무한 스크롤 도입: 페이지 하단 도달 시 자동으로 추가 노트를 로드합니다.
* **버그 수정 / 동작 개선**
  * 노트 생성·삭제 후 목록 반영이 더 정확하고 일관되게 업데이트됩니다.
  * 빈 목록과 로딩 상태 표시가 더 안정적으로 렌더링됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->