### PR TITLE
Fix/274 post form improvements

### DIFF
--- a/src/app/(routers)/(board)/community/_components/DesktopPostHeader.tsx
+++ b/src/app/(routers)/(board)/community/_components/DesktopPostHeader.tsx
@@ -1,3 +1,5 @@
+import { PostHeaderActions } from './PostHeaderActions';
+
 interface DesktopPostHeaderProps {
   isSubmitDisabled: boolean;
   onCancel: () => void;
@@ -16,23 +18,13 @@ export function DesktopPostHeader({
   return (
     <div className="hidden items-center justify-between md:flex">
       <h1 className="font-xl-semibold lg:font-2xl-semibold text-black">{headerTitle}</h1>
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="font-sm-semibold w-[106px] rounded-full border border-gray-300 px-[18px] py-2.5 text-gray-500 hover:bg-gray-50"
-        >
-          취소
-        </button>
-        <button
-          type="button"
-          onClick={onSubmitClick}
-          disabled={isSubmitDisabled}
-          className="font-sm-semibold w-[106px] rounded-full bg-orange-500 px-[18px] py-2.5 text-white disabled:cursor-not-allowed disabled:bg-gray-300"
-        >
-          {submitLabel}
-        </button>
-      </div>
+      <PostHeaderActions
+        variant="desktop"
+        isSubmitDisabled={isSubmitDisabled}
+        submitLabel={submitLabel}
+        onCancel={onCancel}
+        onSubmitClick={onSubmitClick}
+      />
     </div>
   );
 }

--- a/src/app/(routers)/(board)/community/_components/MobilePostHeader.tsx
+++ b/src/app/(routers)/(board)/community/_components/MobilePostHeader.tsx
@@ -1,5 +1,7 @@
 import { SidebarTrigger } from '@/components/ui/sidebar';
 
+import { PostHeaderActions } from './PostHeaderActions';
+
 interface MobilePostHeaderProps {
   isSubmitDisabled: boolean;
   onCancel: () => void;
@@ -25,23 +27,13 @@ export function MobilePostHeader({
             <SidebarTrigger />
             <span className="font-base-semibold text-gray-700">{headerTitle}</span>
           </div>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={onCancel}
-              className="font-sm-medium px-[6px] py-[2px] text-gray-500"
-            >
-              취소
-            </button>
-            <button
-              type="button"
-              onClick={onSubmitClick}
-              disabled={isSubmitDisabled}
-              className="font-sm-semibold px-[6px] py-[2px] text-orange-500 disabled:cursor-not-allowed disabled:text-gray-300"
-            >
-              {submitLabel}
-            </button>
-          </div>
+          <PostHeaderActions
+            variant="mobile"
+            isSubmitDisabled={isSubmitDisabled}
+            submitLabel={submitLabel}
+            onCancel={onCancel}
+            onSubmitClick={onSubmitClick}
+          />
         </header>
         <div className="bg-gray-50 px-4 py-1.5">{toolbar}</div>
       </div>

--- a/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
@@ -14,6 +14,7 @@ import { DeleteIcon } from '@/components/icon/icons/Delete';
 import { Toolbar } from '@/components/Toolbar';
 import { Spinner } from '@/components/ui/spinner';
 
+import { usePostDraft } from '../_hooks/usePostDraft';
 import { usePostEditor } from '../_hooks/usePostEditor';
 import { usePostImages } from '../_hooks/usePostImages';
 import { DesktopPostHeader } from './DesktopPostHeader';
@@ -55,6 +56,7 @@ export function PostFormClient({
   const router = useRouter();
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [submitDialogOpen, setSubmitDialogOpen] = useState(false);
+  const [draftDialogOpen, setDraftDialogOpen] = useState(false);
 
   const { editor, hasEditorContent, hasEditorChanged, charCountWithoutSpaces, charCount } =
     usePostEditor({
@@ -86,6 +88,19 @@ export function PostFormClient({
 
   const titleValue = watch('title');
 
+  const { saveDraft, loadDraft, clearDraft, hasDraft } = usePostDraft({
+    mode,
+    titleValue,
+    editor,
+    setValue,
+  });
+
+  useEffect(() => {
+    if (mode === 'create' && hasDraft()) {
+      setDraftDialogOpen(true);
+    }
+  }, [mode]);
+
   useEffect(() => {
     setValue('charCount', charCount, { shouldValidate: true });
   }, [charCount, setValue]);
@@ -115,6 +130,7 @@ export function PostFormClient({
         .map((item) => item.url);
 
       await onSubmit?.({ title, contentJson }, newFiles, existingUrls);
+      clearDraft();
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : '게시물 저장에 실패했습니다.');
@@ -142,11 +158,21 @@ export function PostFormClient({
       className="flex h-[calc(100dvh-68px)] w-full flex-col overflow-hidden bg-gray-100 md:h-dvh"
     >
       <DeleteDialog
+        open={draftDialogOpen}
+        onOpenChange={setDraftDialogOpen}
+        title="임시저장된 게시물이 있습니다."
+        description="임시저장된 게시물을 불러오시겠습니까?"
+        onConfirm={loadDraft}
+      />
+      <DeleteDialog
         open={cancelDialogOpen}
         onOpenChange={setCancelDialogOpen}
         title="작성을 취소하시겠습니까?"
-        description="작성 중인 내용이 저장되지 않습니다."
-        onConfirm={() => router.back()}
+        description="작성 중인 내용은 임시저장됩니다."
+        onConfirm={() => {
+          if (mode === 'create') saveDraft();
+          router.back();
+        }}
       />
       <DeleteDialog
         open={submitDialogOpen}

--- a/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
@@ -200,7 +200,7 @@ export function PostFormClient({
           </div>
 
           <div
-            className="min-h-0 flex-1 overflow-y-auto px-5 pt-2 md:px-10 [&::-webkit-scrollbar]:hidden"
+            className="min-h-0 flex-1 overflow-y-auto px-5 pt-2 md:px-10"
             onClick={() => editor?.commands.focus()}
           >
             <EditorContent editor={editor} className="text-gray-800" />

--- a/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostFormClient.tsx
@@ -27,7 +27,7 @@ const postSchema = z.object({
     .string()
     .min(1, '제목을 입력해주세요')
     .max(TITLE_MAX_LENGTH, `제목은 최대 ${TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`),
-  content: z
+  charCount: z
     .number()
     .min(1, '내용을 입력해주세요')
     .max(CONTENT_MAX_LENGTH, `내용은 최대 ${CONTENT_MAX_LENGTH}자까지 입력할 수 있습니다.`),
@@ -80,14 +80,14 @@ export function PostFormClient({
     formState: { isSubmitting, isDirty, isValid },
   } = useForm<PostFormValues>({
     resolver: zodResolver(postSchema),
-    defaultValues: { title: initialValues?.title ?? '', content: 0 },
+    defaultValues: { title: initialValues?.title ?? '', charCount: 0 },
     mode: 'onChange',
   });
 
   const titleValue = watch('title');
 
   useEffect(() => {
-    setValue('content', charCount, { shouldValidate: true });
+    setValue('charCount', charCount, { shouldValidate: true });
   }, [charCount, setValue]);
 
   const hasChanged = isDirty || hasEditorChanged || hasImagesChanged;

--- a/src/app/(routers)/(board)/community/_components/PostHeaderActions.tsx
+++ b/src/app/(routers)/(board)/community/_components/PostHeaderActions.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@/lib/shadcn';
+
+interface PostHeaderActionsProps {
+  variant: 'mobile' | 'desktop';
+  isSubmitDisabled: boolean;
+  submitLabel: string;
+  onCancel: () => void;
+  onSubmitClick: () => void;
+}
+
+export function PostHeaderActions({
+  variant,
+  isSubmitDisabled,
+  submitLabel,
+  onCancel,
+  onSubmitClick,
+}: PostHeaderActionsProps) {
+  const isMobile = variant === 'mobile';
+
+  const baseBtn = isMobile ? 'px-[6px] py-[2px]' : 'w-[106px] rounded-full border px-[18px] py-2.5';
+
+  return (
+    <div className={cn('flex items-center', isMobile ? 'gap-1' : 'gap-2')}>
+      <button
+        type="button"
+        onClick={onCancel}
+        className={cn(
+          'font-sm-medium',
+          baseBtn,
+          'text-gray-500',
+          !isMobile && 'font-sm-semibold border-gray-300 hover:bg-gray-50',
+        )}
+      >
+        취소
+      </button>
+      <button
+        type="button"
+        onClick={onSubmitClick}
+        disabled={isSubmitDisabled}
+        className={cn(
+          baseBtn,
+          isMobile
+            ? 'font-sm-semibold text-orange-500 disabled:cursor-not-allowed disabled:text-gray-300'
+            : 'font-sm-semibold bg-orange-500 text-white disabled:cursor-not-allowed disabled:bg-gray-300',
+        )}
+      >
+        {submitLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/app/(routers)/(board)/community/_hooks/usePostDraft.ts
+++ b/src/app/(routers)/(board)/community/_hooks/usePostDraft.ts
@@ -35,18 +35,23 @@ export function usePostDraft({ mode, titleValue, editor, setValue }: UsePostDraf
     const raw = localStorage.getItem(POST_CREATE);
     if (!raw) return;
 
-    const draft = JSON.parse(raw) as PostDraft;
-    setValue('title', draft.title);
-    editor?.commands.setContent(JSON.parse(draft.content));
+    try {
+      const draft = JSON.parse(raw) as PostDraft;
+      setValue('title', draft.title);
+      editor?.commands.setContent(JSON.parse(draft.content));
+    } catch {
+      clearDraft();
+      toast.error('임시저장 데이터가 손상되어 불러올 수 없습니다.');
+    }
   };
 
   const clearDraft = () => localStorage.removeItem(POST_CREATE);
 
   const saveDraft = () => {
-    if (!isCreateMode) return;
+    if (!isCreateMode || !editor) return;
 
-    const content = JSON.stringify(editor?.getJSON());
-    const isEmpty = !titleValue.trim() && editor?.isEmpty;
+    const content = JSON.stringify(editor.getJSON());
+    const isEmpty = !titleValue.trim() && editor.isEmpty;
     if (isEmpty) return;
 
     const draft: PostDraft = {

--- a/src/app/(routers)/(board)/community/_hooks/usePostDraft.ts
+++ b/src/app/(routers)/(board)/community/_hooks/usePostDraft.ts
@@ -55,7 +55,7 @@ export function usePostDraft({ mode, titleValue, editor, setValue }: UsePostDraf
       savedAt: new Date().toISOString(),
     };
     localStorage.setItem(POST_CREATE, JSON.stringify(draft));
-    toast.success('게시글이 임시저장되었습니다.');
+    toast.success('게시글이 임시저장되었습니다.', { id: 'post-create' });
   };
 
   const saveDraftRef = useRef(saveDraft);

--- a/src/app/(routers)/(board)/community/_hooks/usePostDraft.ts
+++ b/src/app/(routers)/(board)/community/_hooks/usePostDraft.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import type { Editor } from '@tiptap/react';
+import type { UseFormSetValue } from 'react-hook-form';
+
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+const POST_CREATE = 'post-create';
+
+interface PostDraft {
+  title: string;
+  content: string;
+  savedAt: string;
+}
+
+type PostDraftFormValues = {
+  title: string;
+  charCount: number;
+};
+
+interface UsePostDraftProps {
+  mode: 'create' | 'edit';
+  titleValue: string;
+  editor: Editor | null;
+  setValue: UseFormSetValue<PostDraftFormValues>;
+}
+
+export function usePostDraft({ mode, titleValue, editor, setValue }: UsePostDraftProps) {
+  const isCreateMode = mode === 'create';
+
+  const hasDraft = () => !!localStorage.getItem(POST_CREATE);
+
+  const loadDraft = () => {
+    const raw = localStorage.getItem(POST_CREATE);
+    if (!raw) return;
+
+    const draft = JSON.parse(raw) as PostDraft;
+    setValue('title', draft.title);
+    editor?.commands.setContent(JSON.parse(draft.content));
+  };
+
+  const clearDraft = () => localStorage.removeItem(POST_CREATE);
+
+  const saveDraft = () => {
+    if (!isCreateMode) return;
+
+    const content = JSON.stringify(editor?.getJSON());
+    const isEmpty = !titleValue.trim() && editor?.isEmpty;
+    if (isEmpty) return;
+
+    const draft: PostDraft = {
+      title: titleValue,
+      content,
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(POST_CREATE, JSON.stringify(draft));
+    toast.success('게시글이 임시저장되었습니다.');
+  };
+
+  const saveDraftRef = useRef(saveDraft);
+  useEffect(() => {
+    saveDraftRef.current = saveDraft;
+  }, [saveDraft]);
+
+  useEffect(() => {
+    if (!isCreateMode) return;
+    const interval = setInterval(() => saveDraftRef.current(), 180 * 1000);
+    return () => clearInterval(interval);
+  }, [isCreateMode]);
+
+  useEffect(() => {
+    if (!isCreateMode) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        saveDraftRef.current();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isCreateMode]);
+
+  return { saveDraft, loadDraft, clearDraft, hasDraft };
+}

--- a/src/app/(routers)/(board)/community/_hooks/usePostEditor.ts
+++ b/src/app/(routers)/(board)/community/_hooks/usePostEditor.ts
@@ -2,7 +2,7 @@
 
 import type { Editor } from '@tiptap/react';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEditorConfig } from '@/hooks/editor';
 
 const isEditorFilled = (editor: Editor) => !editor.isEmpty && editor.getText().trim().length > 0;
@@ -19,19 +19,22 @@ export function usePostEditor({ initialContent, limit }: UsePostEditorOptions = 
     placeholder: '이 곳을 통해 내용을 작성해주세요',
     limit,
   });
-
+  const initialContentRef = useRef(initialContent);
   const [hasEditorContent, setHasEditorContent] = useState(false);
   const [hasEditorChanged, setHasEditorChanged] = useState(false);
   const [charCount, setCharCount] = useState(0);
 
   useEffect(() => {
     if (!editor) return;
+    initialContentRef.current = JSON.stringify(editor.getJSON());
     setHasEditorContent(isEditorFilled(editor));
+    setCharCount(editor.storage.characterCount?.characters() ?? editor.getText().length);
 
     const onUpdate = () => {
+      const currentContent = JSON.stringify(editor.getJSON());
       setHasEditorContent(isEditorFilled(editor));
       setCharCount(editor.storage.characterCount?.characters() ?? editor.getText().length);
-      setHasEditorChanged(true);
+      setHasEditorChanged(currentContent !== initialContentRef.current);
     };
     editor.on('update', onUpdate);
     return () => {


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #274  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- `postSchema` 내 변수명 `content` → `charCount` 수정 (타입 불일치 해소)
- 게시물 작성 시 임시저장 기능 추가 (3분 자동저장, Cmd+S 단축키, 취소 시 저장, 재진입 시 불러오기)
- 스크롤바 숨김 스타일(`[&::-webkit-scrollbar]:hidden`) 제거
- 수정 모드에서 에디터 변경 감지 로직 개선 (단순 flag → 초기 콘텐츠와의 실제 비교)
- `PostHeaderActions` 컴포넌트 분리로 모바일/데스크탑 헤더 버튼 중복 제거

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 타입 불일치로 인한 잠재적 런타임 오류 방지
- 게시물 작성 중 실수로 이탈 시 내용 손실 방지
- 수정 모드에서 내용을 원래대로 되돌렸을 때 수정 버튼이 활성화되는 오동작 수정
- 버튼 로직 변경 시 두 헤더 컴포넌트를 동시에 수정해야 하는 유지보수 비용 제거

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)
<img width="1475" height="754" alt="스크린샷 2026-04-08 오후 2 41 08" src="https://github.com/user-attachments/assets/ac35e0b7-3cd7-40ff-a233-2208a3e07b5e" />


---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 소통게시판 게시물 작성페이지 진입
2. 제목 또는 본문 입력 후 ctrl + s 클릭 시 임시저장 toast 확인
3. 3분 후 자동으로 임시저장 toast 확인
4. 게시물 작성 취소 후 작성페이지 재 진입 시 임시저장 다이얼로그 확인
5. 게시물 등록 후 새로 작성 시 임시저장 다이얼로그 미노출 확인
6. 게시물 수정 시 이미지 변경 또는 추가 시 수정버튼 활성화 확인
7. 게시물 수정 시 본문 동일하게 작성 시 수정버튼 비활성화 확인
```

**예상 결과:**
- 임시저장 시 토스트 노출
- 임시저장된 내용 동일하게 채워짐
- 임시저장 불러오기 취소 시 빈 폼 확인
- 게시물 수정 시 이미지 변경 또는 취소 시 수정버튼 활성화
- 게시물 본문 삭제 후 동일하게 입력 시 수정버튼 비활성화

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 포스트 작성 시 임시 저장(드래프트) 추가 — 자동 저장(3분 간격) 및 Ctrl/Cmd+S 단축키, 드래프트 저장/복원/삭제 지원
  * 작성 중 문자 수(charCount) 실시간 반영 개선

* **Refactor**
  * 취소/제출 버튼 UI를 공통 컴포넌트로 통합하여 모바일/데스크탑 동작 일관성 향상
  * 작성 취소 흐름에서 생성 모드의 드래프트 저장/삭제 동작 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->