### PR TITLE
Fix/318 signup route timeout

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,5 +1,10 @@
+import type { TokenPairBackendResponse } from '@/lib/auth/parseTokenPairFromBackendJson';
+
 import { NextRequest, NextResponse } from 'next/server';
+import { ApiClientError } from '@/lib/apiClient';
+import { apiClientServer } from '@/lib/apiClient.server';
 import { setAuthCookies } from '@/lib/auth/cookies';
+import { isAbortError } from '@/lib/auth/isAbortError';
 import { parseTokenPairFromBackendJson } from '@/lib/auth/parseTokenPairFromBackendJson';
 import {
   loginBodySchema,
@@ -8,7 +13,7 @@ import {
   resolveLoginFailureHttpStatus,
 } from '@/lib/auth/schemas/login';
 
-import { API_BASE_URL, API_TIMEOUT_MS } from '@/constants/api';
+import { API_TIMEOUT_MS } from '@/constants/api';
 import { AUTH_CONFIG } from '@/constants/auth-config';
 import { AUTH_SERVICE_ERROR_MESSAGE_KO } from '@/constants/error-message';
 
@@ -30,36 +35,40 @@ export async function POST(request: NextRequest) {
 
   const { email, password } = parsedBody.data;
 
-  const base = API_BASE_URL?.replace(/\/$/, '') ?? '';
-
   /** 백엔드 연결 실패·성공 본문 JSON 파싱 실패 등 → 제어된 502 (미처리 시 Route Handler 500) */
-  let data: Record<string, unknown>;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
+  let data: TokenPairBackendResponse;
   try {
-    const response = await fetch(`${base}/auth/login`, {
+    data = await apiClientServer<TokenPairBackendResponse>('/auth/login', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-      signal: controller.signal,
+      body: { email, password },
+      retry: false,
+      timeoutMs: API_TIMEOUT_MS,
+      skipSessionExpiredRedirect: true,
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      const raw =
-        err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
-          ? err.message
-          : '로그인 실패';
-      const status = resolveLoginFailureHttpStatus(response.status, err);
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      const backendError = {
+        status: error.status,
+        code: error.code,
+        message: error.message,
+      };
+      const status = resolveLoginFailureHttpStatus(error.status, backendError);
+      const mappedMessage = mapLoginBackendFailureMessage(error.message);
       return NextResponse.json(
-        { success: false, message: mapLoginBackendFailureMessage(raw) },
+        { success: false, message: mappedMessage || '로그인 실패' },
         { status },
       );
     }
+    if (isAbortError(error)) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: AUTH_SERVICE_ERROR_MESSAGE_KO,
+        },
+        { status: 504 },
+      );
+    }
 
-    data = (await response.json()) as Record<string, unknown>;
-  } catch {
     return NextResponse.json(
       {
         success: false,
@@ -67,8 +76,6 @@ export async function POST(request: NextRequest) {
       },
       { status: 502 },
     );
-  } finally {
-    clearTimeout(timeout);
   }
 
   const { accessToken, refreshToken, user } = parseTokenPairFromBackendJson(data);

--- a/src/app/api/auth/oauth/google/callback/route.ts
+++ b/src/app/api/auth/oauth/google/callback/route.ts
@@ -5,14 +5,12 @@ import { NextResponse } from 'next/server';
 import { oauthUserFlashCookieOptions } from '@/lib/auth/cookies';
 import { completeGoogleBackendLogin } from '@/lib/auth/google/completeGoogleBackendLogin';
 import { exchangeGoogleAuthorizationCode } from '@/lib/auth/google/googleTokenExchange';
+import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import {
-  COOKIE_OAUTH_GOOGLE_RETURN_PATH,
-  COOKIE_OAUTH_GOOGLE_STATE,
   COOKIE_OAUTH_USER_FLASH,
   OAUTH_SYNC_USER_QUERY,
   resolveGoogleOAuthRedirectUriForServer,
 } from '@/lib/auth/oauth-urls';
-import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
 import {
   BACKEND_LOGIN_FAILED_MESSAGE_KO,
@@ -44,8 +42,8 @@ export async function GET(request: NextRequest) {
     return loginError(MISSING_OAUTH_RESPONSE_MESSAGE_KO);
   }
 
-  const storedState = request.cookies.get(COOKIE_OAUTH_GOOGLE_STATE)?.value;
-  if (!storedState || storedState !== state) {
+  const verifiedState = verifyOAuthState('google', state);
+  if (!verifiedState.ok) {
     return loginError(SESSION_EXPIRED_OR_INVALID_MESSAGE_KO);
   }
 
@@ -75,16 +73,7 @@ export async function GET(request: NextRequest) {
     return loginError(backend.message);
   }
 
-  const rawReturn = request.cookies.get(COOKIE_OAUTH_GOOGLE_RETURN_PATH)?.value;
-  let decodedReturn: string | null = null;
-  if (rawReturn) {
-    try {
-      decodedReturn = decodeURIComponent(rawReturn);
-    } catch {
-      decodedReturn = null;
-    }
-  }
-  const nextPath = getSafeCallbackPath(decodedReturn) ?? '/dashboard';
+  const nextPath = verifiedState.returnPath;
 
   const target = new URL(nextPath, origin);
   if (backend.user) {
@@ -92,8 +81,6 @@ export async function GET(request: NextRequest) {
   }
 
   const res = NextResponse.redirect(target);
-  res.cookies.set(COOKIE_OAUTH_GOOGLE_STATE, '', { path: '/', maxAge: 0 });
-  res.cookies.set(COOKIE_OAUTH_GOOGLE_RETURN_PATH, '', { path: '/', maxAge: 0 });
 
   if (backend.user) {
     res.cookies.set(

--- a/src/app/api/auth/oauth/google/route.ts
+++ b/src/app/api/auth/oauth/google/route.ts
@@ -1,16 +1,8 @@
 import type { NextRequest } from 'next/server';
 
 import { NextResponse } from 'next/server';
-import { setAuthCookies } from '@/lib/auth/cookies';
-import { parseTokenPairFromBackendJson } from '@/lib/auth/parseTokenPairFromBackendJson';
+import { completeGoogleBackendLogin } from '@/lib/auth/google/completeGoogleBackendLogin';
 import { googleOAuthBodySchema } from '@/lib/auth/schemas/oauth';
-
-import { API_BASE_URL, API_TIMEOUT_MS } from '@/constants/api';
-import { AUTH_CONFIG } from '@/constants/auth-config';
-import {
-  AUTH_SERVICE_ERROR_MESSAGE_KO,
-  DUPLICATE_ACCOUNT_MESSAGE_KO,
-} from '@/constants/error-message';
 
 /**
  * Google OAuth — 클라이언트가 GSI로 받은 `access_token`을 백엔드 `POST .../oauth/google`에 전달.
@@ -31,61 +23,16 @@ export async function POST(request: NextRequest) {
   }
 
   const { accessToken } = parsed.data;
-  const base = API_BASE_URL?.replace(/\/$/, '') ?? '';
+  const result = await completeGoogleBackendLogin(accessToken);
 
-  let data: Record<string, unknown>;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(`${base}/oauth/google`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: accessToken }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      if (response.status === 409) {
-        return NextResponse.json(
-          { success: false, message: DUPLICATE_ACCOUNT_MESSAGE_KO },
-          { status: 409 },
-        );
-      }
-      const raw =
-        err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
-          ? err.message
-          : 'Google 로그인 실패';
-      return NextResponse.json({ success: false, message: raw }, { status: response.status });
-    }
-
-    data = (await response.json()) as Record<string, unknown>;
-  } catch {
+  if (!result.ok) {
     return NextResponse.json(
-      {
-        success: false,
-        message: AUTH_SERVICE_ERROR_MESSAGE_KO,
-      },
-      { status: 502 },
-    );
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  const { accessToken: at, refreshToken: rt, user } = parseTokenPairFromBackendJson(data);
-
-  if (!at || !rt) {
-    return NextResponse.json(
-      {
-        success: false,
-        message: `토큰 응답 형식 오류 (${AUTH_CONFIG.ACCESS_TOKEN_KEY}/${AUTH_CONFIG.REFRESH_TOKEN_KEY})`,
-      },
-      { status: 502 },
+      { success: false, message: result.message },
+      { status: result.status },
     );
   }
 
-  await setAuthCookies(at, rt);
-
-  return NextResponse.json(user ? { success: true as const, user } : { success: true as const });
+  return NextResponse.json(
+    result.user ? { success: true as const, user: result.user } : { success: true as const },
+  );
 }

--- a/src/app/api/auth/oauth/google/start/route.ts
+++ b/src/app/api/auth/oauth/google/start/route.ts
@@ -9,14 +9,18 @@ import {
 } from '@/lib/auth/oauth-urls';
 import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
-import { OAUTH_START_FAILED_MESSAGE_KO } from '@/constants/error-message';
+import {
+  GOOGLE_CLIENT_ID_UNSET_MESSAGE_KO,
+  OAUTH_START_FAILED_MESSAGE_KO,
+} from '@/constants/error-message';
 
 export async function GET(request: NextRequest) {
+  const BRAND_NAME = 'Google';
   const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID?.trim();
   if (!googleClientId) {
     return NextResponse.redirect(
       new URL(
-        '/login?error=NEXT_PUBLIC_GOOGLE_CLIENT_ID가 설정되지 않았습니다.',
+        `/login?error=${encodeURIComponent(`${BRAND_NAME} ${GOOGLE_CLIENT_ID_UNSET_MESSAGE_KO}`)}`,
         request.nextUrl.origin,
       ),
     );
@@ -28,7 +32,7 @@ export async function GET(request: NextRequest) {
   } catch {
     return NextResponse.redirect(
       new URL(
-        `/login?error=${encodeURIComponent(OAUTH_START_FAILED_MESSAGE_KO)}`,
+        `/login?error=${encodeURIComponent(`${BRAND_NAME} ${OAUTH_START_FAILED_MESSAGE_KO}`)}`,
         request.nextUrl.origin,
       ),
     );

--- a/src/app/api/auth/oauth/google/start/route.ts
+++ b/src/app/api/auth/oauth/google/start/route.ts
@@ -1,0 +1,52 @@
+import type { NextRequest } from 'next/server';
+
+import { NextResponse } from 'next/server';
+import { createOAuthState } from '@/lib/auth/oauth-state';
+import {
+  GOOGLE_OAUTH_AUTHORIZE_BASE,
+  GOOGLE_OAUTH_SCOPES,
+  resolveGoogleOAuthRedirectUriForServer,
+} from '@/lib/auth/oauth-urls';
+import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
+
+import { OAUTH_START_FAILED_MESSAGE_KO } from '@/constants/error-message';
+
+export async function GET(request: NextRequest) {
+  const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID?.trim();
+  if (!googleClientId) {
+    return NextResponse.redirect(
+      new URL(
+        '/login?error=NEXT_PUBLIC_GOOGLE_CLIENT_ID가 설정되지 않았습니다.',
+        request.nextUrl.origin,
+      ),
+    );
+  }
+
+  let redirectUri: string;
+  try {
+    redirectUri = resolveGoogleOAuthRedirectUriForServer();
+  } catch {
+    return NextResponse.redirect(
+      new URL(
+        `/login?error=${encodeURIComponent(OAUTH_START_FAILED_MESSAGE_KO)}`,
+        request.nextUrl.origin,
+      ),
+    );
+  }
+
+  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl');
+  const returnPath = getSafeCallbackPath(callbackUrl) ?? '/dashboard';
+  const state = createOAuthState('google', returnPath);
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: googleClientId,
+    redirect_uri: redirectUri,
+    state,
+    scope: GOOGLE_OAUTH_SCOPES,
+    access_type: 'online',
+    include_granted_scopes: 'true',
+  });
+
+  return NextResponse.redirect(`${GOOGLE_OAUTH_AUTHORIZE_BASE}?${params.toString()}`);
+}

--- a/src/app/api/auth/oauth/kakao/callback/route.ts
+++ b/src/app/api/auth/oauth/kakao/callback/route.ts
@@ -5,14 +5,12 @@ import { NextResponse } from 'next/server';
 import { oauthUserFlashCookieOptions } from '@/lib/auth/cookies';
 import { completeKakaoBackendLogin } from '@/lib/auth/kakao/completeKakaoBackendLogin';
 import { exchangeKakaoAuthorizationCode } from '@/lib/auth/kakao/kakaoTokenExchange';
+import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import {
-  COOKIE_OAUTH_KAKAO_RETURN_PATH,
-  COOKIE_OAUTH_KAKAO_STATE,
   COOKIE_OAUTH_USER_FLASH,
   OAUTH_SYNC_USER_QUERY,
   resolveKakaoOAuthRedirectUriForServer,
 } from '@/lib/auth/oauth-urls';
-import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
 import {
   BACKEND_LOGIN_FAILED_MESSAGE_KO,
@@ -44,8 +42,8 @@ export async function GET(request: NextRequest) {
     return loginError(MISSING_OAUTH_RESPONSE_MESSAGE_KO);
   }
 
-  const storedState = request.cookies.get(COOKIE_OAUTH_KAKAO_STATE)?.value;
-  if (!storedState || storedState !== state) {
+  const verifiedState = verifyOAuthState('kakao', state);
+  if (!verifiedState.ok) {
     return loginError(SESSION_EXPIRED_OR_INVALID_MESSAGE_KO);
   }
 
@@ -75,16 +73,7 @@ export async function GET(request: NextRequest) {
     return loginError(backend.message);
   }
 
-  const rawReturn = request.cookies.get(COOKIE_OAUTH_KAKAO_RETURN_PATH)?.value;
-  let decodedReturn: string | null = null;
-  if (rawReturn) {
-    try {
-      decodedReturn = decodeURIComponent(rawReturn);
-    } catch {
-      decodedReturn = null;
-    }
-  }
-  const nextPath = getSafeCallbackPath(decodedReturn) ?? '/dashboard';
+  const nextPath = verifiedState.returnPath;
 
   const target = new URL(nextPath, origin);
   if (backend.user) {
@@ -92,8 +81,6 @@ export async function GET(request: NextRequest) {
   }
 
   const res = NextResponse.redirect(target);
-  res.cookies.set(COOKIE_OAUTH_KAKAO_STATE, '', { path: '/', maxAge: 0 });
-  res.cookies.set(COOKIE_OAUTH_KAKAO_RETURN_PATH, '', { path: '/', maxAge: 0 });
 
   if (backend.user) {
     res.cookies.set(

--- a/src/app/api/auth/oauth/kakao/start/route.ts
+++ b/src/app/api/auth/oauth/kakao/start/route.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from 'next/server';
+
+import { NextResponse } from 'next/server';
+import { createOAuthState } from '@/lib/auth/oauth-state';
+import {
+  KAKAO_OAUTH_AUTHORIZE_BASE,
+  resolveKakaoOAuthRedirectUriForServer,
+} from '@/lib/auth/oauth-urls';
+import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
+
+import { OAUTH_START_FAILED_MESSAGE_KO } from '@/constants/error-message';
+
+export async function GET(request: NextRequest) {
+  const kakaoClientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID?.trim();
+  if (!kakaoClientId) {
+    return NextResponse.redirect(
+      new URL(
+        '/login?error=NEXT_PUBLIC_KAKAO_CLIENT_ID가 설정되지 않았습니다.',
+        request.nextUrl.origin,
+      ),
+    );
+  }
+
+  let redirectUri: string;
+  try {
+    redirectUri = resolveKakaoOAuthRedirectUriForServer();
+  } catch {
+    return NextResponse.redirect(
+      new URL(
+        `/login?error=${encodeURIComponent(OAUTH_START_FAILED_MESSAGE_KO)}`,
+        request.nextUrl.origin,
+      ),
+    );
+  }
+
+  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl');
+  const returnPath = getSafeCallbackPath(callbackUrl) ?? '/dashboard';
+  const state = createOAuthState('kakao', returnPath);
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: kakaoClientId,
+    redirect_uri: redirectUri,
+    state,
+  });
+
+  return NextResponse.redirect(`${KAKAO_OAUTH_AUTHORIZE_BASE}?${params.toString()}`);
+}

--- a/src/app/api/auth/oauth/kakao/start/route.ts
+++ b/src/app/api/auth/oauth/kakao/start/route.ts
@@ -8,14 +8,18 @@ import {
 } from '@/lib/auth/oauth-urls';
 import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
-import { OAUTH_START_FAILED_MESSAGE_KO } from '@/constants/error-message';
+import {
+  KAKAO_CLIENT_ID_UNSET_MESSAGE_KO,
+  OAUTH_START_FAILED_MESSAGE_KO,
+} from '@/constants/error-message';
 
 export async function GET(request: NextRequest) {
+  const BRAND_NAME = 'Kakao';
   const kakaoClientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID?.trim();
   if (!kakaoClientId) {
     return NextResponse.redirect(
       new URL(
-        '/login?error=NEXT_PUBLIC_KAKAO_CLIENT_ID가 설정되지 않았습니다.',
+        `/login?error=${encodeURIComponent(`${BRAND_NAME} ${KAKAO_CLIENT_ID_UNSET_MESSAGE_KO}`)}`,
         request.nextUrl.origin,
       ),
     );
@@ -27,7 +31,7 @@ export async function GET(request: NextRequest) {
   } catch {
     return NextResponse.redirect(
       new URL(
-        `/login?error=${encodeURIComponent(OAUTH_START_FAILED_MESSAGE_KO)}`,
+        `/login?error=${encodeURIComponent(`${BRAND_NAME} ${OAUTH_START_FAILED_MESSAGE_KO}`)}`,
         request.nextUrl.origin,
       ),
     );

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -7,12 +7,17 @@
  *   → **200 OK** + `success: true` + `sessionIssued: false` + `emailVerificationRequired: true`
  * - 가입과 동시에 로그인(토큰 발급)이면 **201 Created** + `sessionIssued: true` + HttpOnly 쿠키 설정.
  */
+import type { TokenPairBackendResponse } from '@/lib/auth/parseTokenPairFromBackendJson';
+
 import { NextRequest, NextResponse } from 'next/server';
+import { ApiClientError } from '@/lib/apiClient';
+import { apiClientServer } from '@/lib/apiClient.server';
 import { setAuthCookies } from '@/lib/auth/cookies';
+import { isAbortError } from '@/lib/auth/isAbortError';
 import { parseTokenPairFromBackendJson } from '@/lib/auth/parseTokenPairFromBackendJson';
 import { signupBodySchema, signupValidationMessage } from '@/lib/auth/schemas/signup';
 
-import { API_BASE_URL } from '@/constants/api';
+import { API_TIMEOUT_MS } from '@/constants/api';
 import {
   AUTH_SERVICE_ERROR_MESSAGE_KO,
   DUPLICATE_ACCOUNT_MESSAGE_KO,
@@ -36,36 +41,36 @@ export async function POST(request: NextRequest) {
 
   const { email, name, password } = parsedBody.data;
 
-  const base = API_BASE_URL?.replace(/\/$/, '') ?? '';
-
-  let data: Record<string, unknown>;
+  let data: TokenPairBackendResponse;
   try {
-    // 백엔드가 다른 경로면 여기만 변경 (예: `/users`, `/auth/register`)
-    const response = await fetch(`${base}/auth/signup`, {
+    data = await apiClientServer<TokenPairBackendResponse>('/auth/signup', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, name, password }),
+      body: { email, name, password },
+      timeoutMs: API_TIMEOUT_MS,
+      skipSessionExpiredRedirect: true,
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      const backendMessage = (err as { message?: string }).message;
-
-      if (response.status === 409) {
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      if (error.status === 409) {
         return NextResponse.json(
           { success: false, message: DUPLICATE_ACCOUNT_MESSAGE_KO },
           { status: 409 },
         );
       }
-
       return NextResponse.json(
-        { success: false, message: backendMessage ?? '회원가입 실패' },
-        { status: response.status },
+        { success: false, message: error.message || '회원가입 실패' },
+        { status: error.status },
       );
     }
-
-    data = (await response.json()) as Record<string, unknown>;
-  } catch {
+    if (isAbortError(error)) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: AUTH_SERVICE_ERROR_MESSAGE_KO,
+        },
+        { status: 504 },
+      );
+    }
     return NextResponse.json(
       {
         success: false,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -42,3 +42,6 @@ export const ALLOWED_ORIGINS = (() => {
 
 /** API 호출 타임아웃 시간 (10초 = 10_000ms) */
 export const API_TIMEOUT_MS = 10_000 as const;
+
+/** 프록시 업스트림 fetch 타임아웃 (스트리밍/대용량 여유를 위해 30초) */
+export const API_PROXY_TIMEOUT_MS = 30_000 as const;

--- a/src/constants/error-message.ts
+++ b/src/constants/error-message.ts
@@ -15,6 +15,8 @@ export const TOKEN_EXCHANGE_FAILED_MESSAGE_KO =
   'OAuth 승인 토큰 교환에 실패했습니다. 다시 시도해 주세요.' as const;
 export const BACKEND_LOGIN_FAILED_MESSAGE_KO =
   '백엔드 로그인에 실패했습니다. 다시 시도해 주세요.' as const;
+export const OAUTH_START_FAILED_MESSAGE_KO =
+  '소셜 로그인 시작에 실패했습니다. 잠시 후 다시 시도해 주세요.' as const;
 export const GOOGLE_CLIENT_ID_UNSET_MESSAGE_KO =
   'NEXT_PUBLIC_GOOGLE_CLIENT_ID가 설정되지 않았습니다.' as const;
 export const GOOGLE_CLIENT_SECRET_UNSET_MESSAGE_KO =
@@ -59,3 +61,9 @@ export const REFRESH_SESSION_NETWORK_MESSAGE_KO = AUTH_SERVICE_ERROR_MESSAGE_KO;
 /** `reason: invalid_token_body` — 200 본문 JSON 파싱 실패 또는 access/refresh 쌍이 없을 때 */
 export const REFRESH_SESSION_INVALID_TOKEN_BODY_MESSAGE_KO =
   '토큰 갱신 응답에 유효한 토큰이 없습니다. 다시 로그인해 주세요.' as const;
+
+export const NO_GOOGLE_CLIENT_SECRET_MESSAGE_KO =
+  'GOOGLE_CLIENT_SECRET가 설정되지 않았습니다.' as const;
+
+export const NO_KAKAO_CLIENT_SECRET_MESSAGE_KO =
+  'KAKAO_CLIENT_SECRET가 설정되지 않았습니다.' as const;

--- a/src/hooks/auth/useGoogleOAuthSignIn.ts
+++ b/src/hooks/auth/useGoogleOAuthSignIn.ts
@@ -5,28 +5,12 @@ import type { User } from '@/lib/auth/schemas/user';
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { ApiClientError } from '@/lib/apiClient';
-import {
-  COOKIE_OAUTH_GOOGLE_RETURN_PATH,
-  COOKIE_OAUTH_GOOGLE_STATE,
-  GOOGLE_OAUTH_AUTHORIZE_BASE,
-  GOOGLE_OAUTH_SCOPES,
-  resolveGoogleOAuthRedirectUri,
-} from '@/lib/auth/oauth-urls';
 import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
 export type GoogleOAuthSignInResult =
   | { ok: true; redirect: true }
   | { ok: true; user?: User; redirect?: false }
   | { ok: false; error: ApiClientError | Error };
-
-const OAUTH_COOKIE_MAX_AGE_SEC = 600;
-
-function setShortLivedCookie(name: string, value: string) {
-  const safe = encodeURIComponent(value);
-  const secure =
-    typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : '';
-  document.cookie = `${name}=${safe}; Path=/; Max-Age=${OAUTH_COOKIE_MAX_AGE_SEC}; SameSite=Lax${secure}`;
-}
 
 function getAppOrigin(): string {
   const fromEnv = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '');
@@ -64,28 +48,10 @@ export function useGoogleOAuthSignIn() {
       };
     }
 
-    const redirectUri = resolveGoogleOAuthRedirectUri(origin);
-    const state = crypto.randomUUID();
     const returnPath = getSafeCallbackPath(searchParams.get('callbackUrl')) ?? '/dashboard';
-
-    try {
-      setShortLivedCookie(COOKIE_OAUTH_GOOGLE_STATE, state);
-      setShortLivedCookie(COOKIE_OAUTH_GOOGLE_RETURN_PATH, returnPath);
-    } catch {
-      return { ok: false, error: new Error('로그인 상태 저장에 실패했습니다.') };
-    }
-
-    const params = new URLSearchParams({
-      response_type: 'code',
-      client_id: googleClientId,
-      redirect_uri: redirectUri,
-      state,
-      scope: GOOGLE_OAUTH_SCOPES,
-      access_type: 'online',
-      include_granted_scopes: 'true',
-    });
-
-    window.location.assign(`${GOOGLE_OAUTH_AUTHORIZE_BASE}?${params.toString()}`);
+    const startUrl = new URL('/api/auth/oauth/google/start', origin);
+    startUrl.searchParams.set('callbackUrl', returnPath);
+    window.location.assign(startUrl.toString());
     return { ok: true, redirect: true };
   }, [googleEnabled, googleClientId, searchParams]);
 

--- a/src/hooks/auth/useKakaoOAuthSignIn.ts
+++ b/src/hooks/auth/useKakaoOAuthSignIn.ts
@@ -5,27 +5,12 @@ import type { User } from '@/lib/auth/schemas/user';
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { ApiClientError } from '@/lib/apiClient';
-import {
-  COOKIE_OAUTH_KAKAO_RETURN_PATH,
-  COOKIE_OAUTH_KAKAO_STATE,
-  KAKAO_OAUTH_AUTHORIZE_BASE,
-  resolveKakaoOAuthRedirectUri,
-} from '@/lib/auth/oauth-urls';
 import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
 export type KakaoOAuthSignInResult =
   | { ok: true; redirect: true }
   | { ok: true; user?: User; redirect?: false }
   | { ok: false; error: ApiClientError | Error };
-
-const OAUTH_COOKIE_MAX_AGE_SEC = 600;
-
-function setShortLivedCookie(name: string, value: string) {
-  const safe = encodeURIComponent(value);
-  const secure =
-    typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : '';
-  document.cookie = `${name}=${safe}; Path=/; Max-Age=${OAUTH_COOKIE_MAX_AGE_SEC}; SameSite=Lax${secure}`;
-}
 
 function getAppOrigin(): string {
   const fromEnv = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '');
@@ -63,25 +48,10 @@ export function useKakaoOAuthSignIn() {
       };
     }
 
-    const redirectUri = resolveKakaoOAuthRedirectUri(origin);
-    const state = crypto.randomUUID();
     const returnPath = getSafeCallbackPath(searchParams.get('callbackUrl')) ?? '/dashboard';
-
-    try {
-      setShortLivedCookie(COOKIE_OAUTH_KAKAO_STATE, state);
-      setShortLivedCookie(COOKIE_OAUTH_KAKAO_RETURN_PATH, returnPath);
-    } catch {
-      return { ok: false, error: new Error('로그인 상태 저장에 실패했습니다.') };
-    }
-
-    const params = new URLSearchParams({
-      response_type: 'code',
-      client_id: kakaoKey,
-      redirect_uri: redirectUri,
-      state,
-    });
-
-    window.location.assign(`${KAKAO_OAUTH_AUTHORIZE_BASE}?${params.toString()}`);
+    const startUrl = new URL('/api/auth/oauth/kakao/start', origin);
+    startUrl.searchParams.set('callbackUrl', returnPath);
+    window.location.assign(startUrl.toString());
     return { ok: true, redirect: true };
   }, [kakaoEnabled, kakaoKey, searchParams]);
 

--- a/src/lib/apiClient.core.ts
+++ b/src/lib/apiClient.core.ts
@@ -2,6 +2,8 @@
  * 환경 무관 `createApiClient` 팩토리 — `cookies` / `server-only` import 금지.
  */
 
+import { fetchWithTimeout } from '@/lib/fetchWithTimeout';
+
 import { AUTH_TOKENS_EXPIRED_MESSAGE_KO } from '@/constants/error-message';
 
 /**
@@ -30,6 +32,7 @@ export type ClientPublicApiBase = '/api/proxy' | '/api/auth';
 
 export type ApiClientConfig = Omit<RequestInit, 'body'> & {
   body?: unknown;
+  timeoutMs?: number;
   responseType?: ApiClientResponseType;
   retry?: boolean;
   next?: NextFetchConfig;
@@ -196,6 +199,7 @@ export function createApiClient(deps: CreateApiClientDeps): ApiClientInstance {
   async function request<T = unknown>(endpoint: string, config: ApiClientConfig = {}): Promise<T> {
     const {
       body,
+      timeoutMs,
       responseType = 'json',
       retry = true,
       headers: customHeaders,
@@ -246,10 +250,20 @@ export function createApiClient(deps: CreateApiClientDeps): ApiClientInstance {
     const { url: finalUrl, ...fetchOpts } = requestInput;
 
     const fetchExtra = deps.buildFetchNext?.(nextConfig);
-    const response = await fetch(finalUrl, {
-      ...fetchOpts,
-      ...fetchExtra,
-    });
+    const response =
+      typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? await fetchWithTimeout(
+            finalUrl,
+            {
+              ...fetchOpts,
+              ...fetchExtra,
+            },
+            timeoutMs,
+          )
+        : await fetch(finalUrl, {
+            ...fetchOpts,
+            ...fetchExtra,
+          });
 
     if (response.status === 401 && retry) {
       const refreshed = await attemptRefresh();

--- a/src/lib/auth/__tests__/parseTokenPairFromBackendJson.test.ts
+++ b/src/lib/auth/__tests__/parseTokenPairFromBackendJson.test.ts
@@ -33,7 +33,7 @@ describe('parseTokenPairFromBackendJson', () => {
       [AUTH_CONFIG.ACCESS_TOKEN_JSON_ALTERNATE]: 'at',
       [AUTH_CONFIG.REFRESH_TOKEN_JSON_ALTERNATE]: 'rt',
       [AUTH_CONFIG.USER_OBJECT_JSON_ALTERNATE]: {
-        id: 99,
+        id: '99',
         email: 'c@d.com',
         name: 'Lee',
         image: 'https://placehold.co/38x38?text=S',

--- a/src/lib/auth/google/completeGoogleBackendLogin.ts
+++ b/src/lib/auth/google/completeGoogleBackendLogin.ts
@@ -1,11 +1,15 @@
 import 'server-only';
 
+import type { TokenPairBackendResponse } from '@/lib/auth/parseTokenPairFromBackendJson';
 import type { User } from '@/lib/auth/schemas/user';
 
+import { ApiClientError } from '@/lib/apiClient';
+import { apiClientServer } from '@/lib/apiClient.server';
 import { setAuthCookies } from '@/lib/auth/cookies';
+import { isAbortError } from '@/lib/auth/isAbortError';
 import { parseTokenPairFromBackendJson } from '@/lib/auth/parseTokenPairFromBackendJson';
 
-import { API_BASE_URL, API_TIMEOUT_MS } from '@/constants/api';
+import { API_TIMEOUT_MS } from '@/constants/api';
 import { AUTH_CONFIG } from '@/constants/auth-config';
 import {
   AUTH_SERVICE_ERROR_MESSAGE_KO,
@@ -23,31 +27,13 @@ export type CompleteGoogleBackendLoginResult =
 export async function completeGoogleBackendLogin(
   googleAccessToken: string,
 ): Promise<CompleteGoogleBackendLoginResult> {
-  const base = API_BASE_URL?.replace(/\/$/, '') ?? '';
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
   try {
-    const response = await fetch(`${base}/oauth/google`, {
+    const data = await apiClientServer<TokenPairBackendResponse>('/oauth/google', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: googleAccessToken }),
-      signal: controller.signal,
+      body: { token: googleAccessToken },
+      timeoutMs: API_TIMEOUT_MS,
+      skipSessionExpiredRedirect: true,
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      if (response.status === 409) {
-        return { ok: false, status: 409, message: DUPLICATE_ACCOUNT_MESSAGE_KO };
-      }
-      const raw =
-        err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
-          ? err.message
-          : 'Google 로그인 실패';
-      return { ok: false, status: response.status, message: raw };
-    }
-
-    const data = (await response.json()) as Record<string, unknown>;
     const { accessToken: at, refreshToken: rt, user } = parseTokenPairFromBackendJson(data);
 
     if (!at || !rt) {
@@ -60,13 +46,24 @@ export async function completeGoogleBackendLogin(
 
     await setAuthCookies(at, rt);
     return { ok: true, user };
-  } catch {
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      if (error.status === 409) {
+        return { ok: false, status: 409, message: DUPLICATE_ACCOUNT_MESSAGE_KO };
+      }
+      return { ok: false, status: error.status, message: error.message || 'Google 로그인 실패' };
+    }
+    if (isAbortError(error)) {
+      return {
+        ok: false,
+        status: 504,
+        message: AUTH_SERVICE_ERROR_MESSAGE_KO,
+      };
+    }
     return {
       ok: false,
       status: 502,
       message: AUTH_SERVICE_ERROR_MESSAGE_KO,
     };
-  } finally {
-    clearTimeout(timeout);
   }
 }

--- a/src/lib/auth/isAbortError.ts
+++ b/src/lib/auth/isAbortError.ts
@@ -1,0 +1,3 @@
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/src/lib/auth/kakao/completeKakaoBackendLogin.ts
+++ b/src/lib/auth/kakao/completeKakaoBackendLogin.ts
@@ -1,11 +1,15 @@
 import 'server-only';
 
+import type { TokenPairBackendResponse } from '@/lib/auth/parseTokenPairFromBackendJson';
 import type { User } from '@/lib/auth/schemas/user';
 
+import { ApiClientError } from '@/lib/apiClient';
+import { apiClientServer } from '@/lib/apiClient.server';
 import { setAuthCookies } from '@/lib/auth/cookies';
+import { isAbortError } from '@/lib/auth/isAbortError';
 import { parseTokenPairFromBackendJson } from '@/lib/auth/parseTokenPairFromBackendJson';
 
-import { API_BASE_URL, API_TIMEOUT_MS } from '@/constants/api';
+import { API_TIMEOUT_MS } from '@/constants/api';
 import { AUTH_CONFIG } from '@/constants/auth-config';
 import {
   AUTH_SERVICE_ERROR_MESSAGE_KO,
@@ -23,31 +27,13 @@ export type CompleteKakaoBackendLoginResult =
 export async function completeKakaoBackendLogin(
   kakaoAccessToken: string,
 ): Promise<CompleteKakaoBackendLoginResult> {
-  const base = API_BASE_URL?.replace(/\/$/, '') ?? '';
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
   try {
-    const response = await fetch(`${base}/oauth/kakao`, {
+    const data = await apiClientServer<TokenPairBackendResponse>('/oauth/kakao', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: kakaoAccessToken }),
-      signal: controller.signal,
+      body: { token: kakaoAccessToken },
+      timeoutMs: API_TIMEOUT_MS,
+      skipSessionExpiredRedirect: true,
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      if (response.status === 409) {
-        return { ok: false, status: 409, message: DUPLICATE_ACCOUNT_MESSAGE_KO };
-      }
-      const raw =
-        err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
-          ? err.message
-          : '카카오 로그인 실패';
-      return { ok: false, status: response.status, message: raw };
-    }
-
-    const data = (await response.json()) as Record<string, unknown>;
     const { accessToken: at, refreshToken: rt, user } = parseTokenPairFromBackendJson(data);
 
     if (!at || !rt) {
@@ -60,13 +46,24 @@ export async function completeKakaoBackendLogin(
 
     await setAuthCookies(at, rt);
     return { ok: true, user };
-  } catch {
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      if (error.status === 409) {
+        return { ok: false, status: 409, message: DUPLICATE_ACCOUNT_MESSAGE_KO };
+      }
+      return { ok: false, status: error.status, message: error.message || '카카오 로그인 실패' };
+    }
+    if (isAbortError(error)) {
+      return {
+        ok: false,
+        status: 504,
+        message: AUTH_SERVICE_ERROR_MESSAGE_KO,
+      };
+    }
     return {
       ok: false,
       status: 502,
       message: AUTH_SERVICE_ERROR_MESSAGE_KO,
     };
-  } finally {
-    clearTimeout(timeout);
   }
 }

--- a/src/lib/auth/oauth-state.ts
+++ b/src/lib/auth/oauth-state.ts
@@ -1,3 +1,4 @@
+;
 /**
  * Node.js Runtime 전용.
  *
@@ -6,14 +7,21 @@
  */
 import 'server-only';
 
+
+
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+
+
 
 import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
-import {
-  NO_GOOGLE_CLIENT_SECRET_MESSAGE_KO,
-  NO_KAKAO_CLIENT_SECRET_MESSAGE_KO,
-} from '@/constants/error-message';
+
+
+import { NO_GOOGLE_CLIENT_SECRET_MESSAGE_KO, NO_KAKAO_CLIENT_SECRET_MESSAGE_KO } from '@/constants/error-message';
+
+
+
+
 
 /**
  * OAuth `state` 유효 시간(10분).
@@ -238,6 +246,12 @@ export function verifyOAuthState(
    * nonce 형식/1회성 소비 검증.
    */
   if (typeof payload.n !== 'string' || payload.n.length < 8) return { ok: false };
+
+  /**
+   * JSON.parse + 단언만으로는 `r`이 string이 아닐 수 있음.
+   * (예: 조작된 state에서 `r`이 number/object면 `getSafeCallbackPath`의 trim에서 예외)
+   */
+  if (typeof payload.r !== 'string') return { ok: false };
   if (!consumeNonce(provider, payload.n, payload.e)) return { ok: false };
 
   /**

--- a/src/lib/auth/oauth-state.ts
+++ b/src/lib/auth/oauth-state.ts
@@ -19,7 +19,7 @@ const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 /**
  * 메모리 nonce 저장소 상한.
  * - 비정상 트래픽/공격으로 nonce가 무한 적재되는 상황을 완화하기 위한 안전장치.
- * - 상한 도달 시 가장 오래된 엔트리를 제거해 메모리 폭주를 방지.
+ * - 상한 도달 시 만료 시각이 가장 이른 엔트리를 제거해 메모리 폭주를 방지.
  */
 const NONCE_STORE_MAX_SIZE = 20_000;
 
@@ -62,6 +62,19 @@ function pruneNonceStore(now: number): void {
   }
 }
 
+/** 상한 초과 시 `expiresAt`이 최소인 엔트리(가장 먼저 만료되는 nonce)를 제거 */
+function evictEarliestExpiringNonce(): void {
+  let victimKey: string | undefined;
+  let minExpiresAt = Infinity;
+  for (const [key, expiresAt] of usedNonceStore) {
+    if (expiresAt < minExpiresAt) {
+      minExpiresAt = expiresAt;
+      victimKey = key;
+    }
+  }
+  if (victimKey !== undefined) usedNonceStore.delete(victimKey);
+}
+
 /**
  * nonce를 "1회 소비" 처리한다.
  * - 이미 사용된 nonce면 false (replay 차단)
@@ -79,9 +92,8 @@ function consumeNonce(provider: OAuthProvider, nonce: string, expiresAt: number)
   if (usedNonceStore.has(nonceKey)) return false;
 
   if (usedNonceStore.size >= NONCE_STORE_MAX_SIZE) {
-    // store가 비정상적으로 커졌을 때, 만료된 엔트리 정리 후에도 꽉 차면 가장 오래된 키를 제거
-    const oldestKey = usedNonceStore.keys().next().value;
-    if (oldestKey) usedNonceStore.delete(oldestKey);
+    // prune 후에도 꽉 차면 만료 시각이 가장 이른 엔트리를 제거(Map 삽입 순서와 무관)
+    evictEarliestExpiringNonce();
   }
 
   usedNonceStore.set(nonceKey, expiresAt);

--- a/src/lib/auth/oauth-state.ts
+++ b/src/lib/auth/oauth-state.ts
@@ -1,3 +1,9 @@
+/**
+ * Node.js Runtime 전용.
+ *
+ * OAuth state 서명/검증에 `node:crypto` 등 Node.js 전용 API를 사용합니다.
+ * Edge Runtime 또는 Edge에서 번들되는 경로에서 이 모듈을 import 하지 마세요.
+ */
 import 'server-only';
 
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';

--- a/src/lib/auth/oauth-state.ts
+++ b/src/lib/auth/oauth-state.ts
@@ -1,0 +1,235 @@
+import 'server-only';
+
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+
+import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
+
+import {
+  NO_GOOGLE_CLIENT_SECRET_MESSAGE_KO,
+  NO_KAKAO_CLIENT_SECRET_MESSAGE_KO,
+} from '@/constants/error-message';
+
+/**
+ * OAuth `state` 유효 시간(10분).
+ * - 너무 길면 탈취/재사용 윈도우가 늘어나고
+ * - 너무 짧으면 사용자 인증 과정에서 만료될 수 있어 UX가 나빠질 수 있음.
+ */
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * 메모리 nonce 저장소 상한.
+ * - 비정상 트래픽/공격으로 nonce가 무한 적재되는 상황을 완화하기 위한 안전장치.
+ * - 상한 도달 시 가장 오래된 엔트리를 제거해 메모리 폭주를 방지.
+ */
+const NONCE_STORE_MAX_SIZE = 20_000;
+
+/**
+ * OAuth 공급자 (현재는 구글, 카카오만 지원)
+ */
+type OAuthProvider = 'google' | 'kakao';
+
+/**
+ * state payload를 짧게 유지하기 위해 축약 키 사용.
+ * - p: provider (`google` | `kakao`) - 교차 provider 재사용 방지
+ * - r: returnPath - 로그인 후 내부 리다이렉트 경로
+ * - e: expiresAt(ms) - 만료 시각
+ * - n: nonce - 동일 요청 구분용 랜덤 값
+ */
+type OAuthStatePayload = {
+  p: OAuthProvider;
+  r: string;
+  e: number;
+  n: string;
+};
+
+/**
+ * nonce 재사용(replay) 방지를 위한 프로세스 메모리 저장소.
+ *
+ * 주의:
+ * - 단일 인스턴스/프로세스 기준 방어.
+ * - 멀티 인스턴스 환경에서는 인스턴스 간 nonce 상태가 공유되지 않으므로
+ *   완전한 전역 replay 방어를 위해 Redis/KV 같은 공유 저장소가 필요함.
+ */
+const usedNonceStore = new Map<string, number>();
+
+/**
+ * 만료된 nonce 엔트리 정리.
+ * verify 시점마다 호출해 저장소를 TTL 기준으로 청소한다.
+ */
+function pruneNonceStore(now: number): void {
+  for (const [nonceKey, expiresAt] of usedNonceStore.entries()) {
+    if (expiresAt < now) usedNonceStore.delete(nonceKey);
+  }
+}
+
+/**
+ * nonce를 "1회 소비" 처리한다.
+ * - 이미 사용된 nonce면 false (replay 차단)
+ * - 최초 사용이면 저장 후 true
+ *
+ * 서버리스 주의:
+ * - 이 로직은 "현재 인스턴스" 기준으로만 replay를 차단한다.
+ * - 인스턴스가 달라지면 저장소가 공유되지 않으므로 전역 replay 차단은 보장하지 않는다.
+ * - 본 프로젝트는 Vercel(서버리스) 전제를 고려해, 전역 방어 대신 비용/복잡도 균형으로 이 수준을 채택.
+ */
+function consumeNonce(provider: OAuthProvider, nonce: string, expiresAt: number): boolean {
+  const now = Date.now();
+  pruneNonceStore(now);
+  const nonceKey = `${provider}:${nonce}`;
+  if (usedNonceStore.has(nonceKey)) return false;
+
+  if (usedNonceStore.size >= NONCE_STORE_MAX_SIZE) {
+    // store가 비정상적으로 커졌을 때, 만료된 엔트리 정리 후에도 꽉 차면 가장 오래된 키를 제거
+    const oldestKey = usedNonceStore.keys().next().value;
+    if (oldestKey) usedNonceStore.delete(oldestKey);
+  }
+
+  usedNonceStore.set(nonceKey, expiresAt);
+  return true;
+}
+
+/**
+ * URL query에 안전하게 넣기 위해 base64url 인코딩 사용.
+ * (`+`, `/`, `=` 제거되어 URL 인코딩 부담이 줄어듦)
+ */
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+function base64UrlDecode(input: string): string {
+  return Buffer.from(input, 'base64url').toString('utf8');
+}
+
+/**
+ * provider별 OAuth client secret 조회.
+ * 별도 state 전용 secret을 두지 않고 기존 OAuth 공급자의 client secret을 재사용
+ */
+function getProviderSecret(provider: OAuthProvider): string {
+  if (provider === 'google') {
+    const secret = process.env.GOOGLE_CLIENT_SECRET?.trim();
+    if (!secret) throw new Error(NO_GOOGLE_CLIENT_SECRET_MESSAGE_KO);
+    return secret;
+  }
+
+  const secret = process.env.KAKAO_CLIENT_SECRET?.trim();
+  if (!secret) throw new Error(NO_KAKAO_CLIENT_SECRET_MESSAGE_KO);
+  return secret;
+}
+
+/**
+ * payload(base64url)에 대해 HMAC-SHA256 서명 생성.
+ * 반환값은 base64url 문자열이며 state의 두 번째 파트로 사용.
+ */
+function signPayload(provider: OAuthProvider, encodedPayload: string): string {
+  const secret = getProviderSecret(provider);
+  return createHmac('sha256', secret).update(encodedPayload).digest('base64url');
+}
+
+/**
+ * 서명 비교 시 timing attack 가능성을 줄이기 위해 상수 시간 비교 사용.
+ * - 길이가 다르면 즉시 false
+ * - 길이가 같을 때만 timingSafeEqual 수행
+ */
+function isSameSignature(expected: string, provided: string): boolean {
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const providedBuffer = Buffer.from(provided, 'utf8');
+  if (expectedBuffer.length !== providedBuffer.length) return false;
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+/**
+ * OAuth 시작 시 state 생성.
+ *
+ * 형식: `<base64url(payload)>.<base64url(hmac)>`
+ * - payload는 provider/returnPath/expiry/nonce를 포함
+ * - returnPath는 생성 시점에 먼저 sanitize해서 내부 경로만 허용
+ * - 서버 저장소(DB/Redis/cookie) 없이 stateless 검증 가능
+ */
+export function createOAuthState(provider: OAuthProvider, callbackPath: string): string {
+  const safePath = getSafeCallbackPath(callbackPath) ?? '/dashboard';
+  const payload: OAuthStatePayload = {
+    p: provider,
+    r: safePath,
+    e: Date.now() + OAUTH_STATE_TTL_MS,
+    n: randomUUID(),
+  };
+
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = signPayload(provider, encodedPayload);
+  return `${encodedPayload}.${signature}`;
+}
+
+/**
+ * OAuth 콜백에서 state 검증.
+ *
+ * 검증 순서:
+ * 1) 포맷 검증 (`payload.signature`)
+ * 2) 서명 검증 (위변조 여부)
+ * 3) payload JSON 파싱
+ * 4) provider 일치 검증 (google state를 kakao에 재사용 방지)
+ * 5) 만료 검증
+ * 6) nonce 1회성 소비 검증 (현재 인스턴스 기준 replay 방지)
+ * 7) returnPath 재검증 (오픈 리다이렉트 방지)
+ *
+ * 하나라도 실패하면 `{ ok: false }` 반환.
+ */
+export function verifyOAuthState(
+  provider: OAuthProvider,
+  state: string,
+): { ok: true; returnPath: string } | { ok: false } {
+  /**
+   * state는 `<base64url(payload)>.<base64url(hmac)>` 형식으로 구성되어 있음.
+   * 따라서 `.`을 기준으로 분리하여 파싱.
+   */
+  const parts = state.split('.');
+  if (parts.length !== 2) return { ok: false };
+
+  /**
+   * 분리된 두 부분(payload, hmac)이 모두 존재하는지 확인.
+   */
+  const [encodedPayload, providedSignature] = parts;
+  if (!encodedPayload || !providedSignature) return { ok: false };
+
+  /**
+   * 서명 검증.
+   */
+  const expectedSignature = signPayload(provider, encodedPayload);
+  if (!isSameSignature(expectedSignature, providedSignature)) return { ok: false };
+
+  /**
+   * payload JSON 파싱.
+   */
+  let payload: OAuthStatePayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as OAuthStatePayload;
+  } catch {
+    return { ok: false };
+  }
+
+  /**
+   * provider 일치 검증.
+   */
+  if (payload.p !== provider) return { ok: false };
+
+  /**
+   * 만료 검증.
+   */
+  if (typeof payload.e !== 'number' || payload.e < Date.now()) return { ok: false };
+
+  /**
+   * nonce 형식/1회성 소비 검증.
+   */
+  if (typeof payload.n !== 'string' || payload.n.length < 8) return { ok: false };
+  if (!consumeNonce(provider, payload.n, payload.e)) return { ok: false };
+
+  /**
+   * returnPath 재검증.
+   */
+  const safePath = getSafeCallbackPath(payload.r);
+  if (!safePath) return { ok: false };
+
+  /**
+   * 검증 성공.
+   */
+  return { ok: true, returnPath: safePath };
+}

--- a/src/lib/auth/oauth-urls.ts
+++ b/src/lib/auth/oauth-urls.ts
@@ -10,10 +10,6 @@ export const KAKAO_OAUTH_CALLBACK_PATH = '/api/auth/oauth/kakao/callback' as con
 export const STORAGE_OAUTH_KAKAO_STATE = 'oauth_kakao_state' as const;
 export const STORAGE_OAUTH_KAKAO_RETURN_PATH = 'oauth_kakao_return_path' as const;
 
-/** 서버 콜백에서 `state` 검증용 (클라이언트가 authorize 직전에 설정) */
-export const COOKIE_OAUTH_KAKAO_STATE = 'oauth_kakao_state' as const;
-export const COOKIE_OAUTH_KAKAO_RETURN_PATH = 'oauth_kakao_return_path' as const;
-
 /** 카카오 콜백 직후 1회 — 클라이언트가 `authUserStore`에 동기화할 때까지 잠깐 보관 (HttpOnly) */
 export const COOKIE_OAUTH_USER_FLASH = 'oauth_user_flash' as const;
 
@@ -57,9 +53,6 @@ export const GOOGLE_OAUTH_CALLBACK_PATH = '/api/auth/oauth/google/callback' as c
 
 export const STORAGE_OAUTH_GOOGLE_STATE = 'oauth_google_state' as const;
 export const STORAGE_OAUTH_GOOGLE_RETURN_PATH = 'oauth_google_return_path' as const;
-
-export const COOKIE_OAUTH_GOOGLE_STATE = 'oauth_google_state' as const;
-export const COOKIE_OAUTH_GOOGLE_RETURN_PATH = 'oauth_google_return_path' as const;
 
 /** 로그인 시 요청 scope — 토큰 클라이언트·Authorization Code 공통 */
 export const GOOGLE_OAUTH_SCOPES = 'openid email profile' as const;

--- a/src/lib/auth/parseTokenPairFromBackendJson.ts
+++ b/src/lib/auth/parseTokenPairFromBackendJson.ts
@@ -4,11 +4,27 @@ import { parseUserFromBackendUnknown } from '@/lib/auth/schemas/user';
 
 import { AUTH_CONFIG } from '@/constants/auth-config';
 
+type BackendUserLike = Partial<User> & Record<string, unknown>;
+
+/**
+ * 백엔드 auth 응답(로그인/리프레시)에서 기대하는 최소 계약.
+ * - 토큰 키는 snake/camel 대체 키를 모두 허용
+ * - user는 앱 User 스키마 기반의 부분집합 + 백엔드 확장 필드 허용
+ */
+export type TokenPairBackendResponse = {
+  [AUTH_CONFIG.ACCESS_TOKEN_KEY]?: string;
+  [AUTH_CONFIG.ACCESS_TOKEN_JSON_ALTERNATE]?: string;
+  [AUTH_CONFIG.REFRESH_TOKEN_KEY]?: string;
+  [AUTH_CONFIG.REFRESH_TOKEN_JSON_ALTERNATE]?: string;
+  [AUTH_CONFIG.USER_OBJECT_KEY]?: BackendUserLike;
+  [AUTH_CONFIG.USER_OBJECT_JSON_ALTERNATE]?: BackendUserLike;
+} & Record<string, unknown>;
+
 /**
  * 백엔드 login/refresh JSON에서 토큰 쌍을 읽는다.
  * 스네이크(`AUTH_CONFIG.*_KEY`) 우선, camelCase(`*_JSON_ALTERNATE`) 대체.
  */
-export function parseTokenPairFromBackendJson(data: Record<string, unknown>): {
+export function parseTokenPairFromBackendJson(data: TokenPairBackendResponse): {
   accessToken: string | undefined;
   refreshToken: string | undefined;
   user: User | undefined;
@@ -27,7 +43,7 @@ export function parseTokenPairFromBackendJson(data: Record<string, unknown>): {
   return { accessToken, refreshToken, user };
 }
 
-function pickUserObject(data: Record<string, unknown>): unknown {
+function pickUserObject(data: TokenPairBackendResponse): unknown {
   const primary = data[AUTH_CONFIG.USER_OBJECT_KEY];
   const alternate = data[AUTH_CONFIG.USER_OBJECT_JSON_ALTERNATE];
   const v = primary !== undefined && primary !== null ? primary : alternate;
@@ -35,7 +51,7 @@ function pickUserObject(data: Record<string, unknown>): unknown {
   return undefined;
 }
 
-function pickString(data: Record<string, unknown>, key: string): string | undefined {
+function pickString(data: TokenPairBackendResponse, key: string): string | undefined {
   const v = data[key];
   return typeof v === 'string' && v.length > 0 ? v : undefined;
 }

--- a/src/lib/auth/refreshSession.server.ts
+++ b/src/lib/auth/refreshSession.server.ts
@@ -6,13 +6,14 @@
  */
 import 'server-only';
 
+import type { TokenPairBackendResponse } from '@/lib/auth/parseTokenPairFromBackendJson';
 import type { User } from '@/lib/auth/schemas/user';
 
+import { ApiClientError } from '@/lib/apiClient';
+import { apiClientServer } from '@/lib/apiClient.server';
 import { getRefreshToken, setAuthCookies } from '@/lib/auth/cookies';
 import { parseTokenPairFromBackendJson } from '@/lib/auth/parseTokenPairFromBackendJson';
-import { fetchWithTimeout } from '@/lib/fetchWithTimeout';
 
-import { API_BASE_URL } from '@/constants/api';
 import { AUTH_CONFIG } from '@/constants/auth-config';
 import {
   REFRESH_SESSION_BACKEND_REJECTED_FALLBACK_MESSAGE_KO,
@@ -115,44 +116,32 @@ function putRefreshSuccessCache(refreshToken: string, result: RefreshBackendSucc
  * @returns 성공 시 파싱된 토큰·user, 실패 시 이유 코드. 쿠키는 건드리지 않음.
  */
 async function fetchRefreshFromBackend(refreshToken: string): Promise<RefreshBackendResult> {
-  const base = API_BASE_URL?.replace(/\/$/, '') ?? '';
   const timeoutMs = AUTH_CONFIG.REFRESH_FETCH_TIMEOUT_MS;
 
-  let response: Response;
+  let data: TokenPairBackendResponse;
   try {
-    response = await fetchWithTimeout(
-      `${base}/auth/refresh`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          [AUTH_CONFIG.REFRESH_TOKEN_JSON_ALTERNATE]: refreshToken,
-        }),
+    data = await apiClientServer<TokenPairBackendResponse>('/auth/refresh', {
+      method: 'POST',
+      body: {
+        [AUTH_CONFIG.REFRESH_TOKEN_JSON_ALTERNATE]: refreshToken,
       },
+      retry: false,
       timeoutMs,
-    );
-  } catch {
-    return { ok: false, reason: REFRESH_SESSION_REASON.NETWORK };
-  }
-
-  if (!response.ok) {
-    const errBody = await response.json().catch(() => ({}));
-    const message =
-      (errBody as { message?: string }).message ??
-      (errBody as { error?: string }).error ??
-      REFRESH_SESSION_BACKEND_REJECTED_FALLBACK_MESSAGE_KO;
-    return {
-      ok: false,
-      reason: REFRESH_SESSION_REASON.BACKEND_REJECTED,
-      status: response.status,
-      message,
-    };
-  }
-
-  let data: Record<string, unknown>;
-  try {
-    data = (await response.json()) as Record<string, unknown>;
-  } catch {
+      skipSessionExpiredRedirect: true,
+    });
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      return {
+        ok: false,
+        reason: REFRESH_SESSION_REASON.BACKEND_REJECTED,
+        status: error.status,
+        message: error.message || REFRESH_SESSION_BACKEND_REJECTED_FALLBACK_MESSAGE_KO,
+      };
+    }
+    if (isLikelyNetworkError(error)) {
+      return { ok: false, reason: REFRESH_SESSION_REASON.NETWORK };
+    }
+    // apiClient의 2xx JSON 파싱 실패/본문 형식 불일치 등은 본문 계약 위반으로 분류.
     return { ok: false, reason: REFRESH_SESSION_REASON.INVALID_TOKEN_BODY };
   }
 
@@ -167,6 +156,21 @@ async function fetchRefreshFromBackend(refreshToken: string): Promise<RefreshBac
   }
 
   return { ok: true, accessToken: newAccessToken, refreshToken: newRefreshToken, user };
+}
+
+function isLikelyNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError') return true;
+  const m = (error.message ?? '').toLowerCase();
+  return (
+    m.includes('econn') ||
+    m.includes('enotfound') ||
+    m.includes('etimedout') ||
+    m.includes('network') ||
+    m.includes('fetch failed') ||
+    m.includes('socket') ||
+    m.includes('connect')
+  );
 }
 
 /**

--- a/src/lib/navigation/__tests__/safeCallbackPath.test.ts
+++ b/src/lib/navigation/__tests__/safeCallbackPath.test.ts
@@ -1,4 +1,8 @@
-import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
+import {
+  getSafeCallbackPath,
+  SAFE_CALLBACK_PATH_MAX_LENGTH,
+  SAFE_CALLBACK_RAW_MAX_LENGTH,
+} from '@/lib/navigation/safeCallbackPath';
 
 describe('getSafeCallbackPath', () => {
   it('null·빈 문자열 → null', () => {
@@ -18,5 +22,39 @@ describe('getSafeCallbackPath', () => {
     expect(getSafeCallbackPath('//evil.com')).toBeNull();
     expect(getSafeCallbackPath('%2F%2Fevil.com')).toBeNull();
     expect(getSafeCallbackPath('javascript:alert(1)')).toBeNull();
+  });
+
+  it('길이 상한: 원문(encoded 기준) 초과 → null', () => {
+    const tooLongRaw = `/${'a'.repeat(SAFE_CALLBACK_RAW_MAX_LENGTH)}`;
+    expect(tooLongRaw.length).toBe(SAFE_CALLBACK_RAW_MAX_LENGTH + 1);
+    expect(getSafeCallbackPath(tooLongRaw)).toBeNull();
+  });
+
+  it('길이 상한: 디코딩 후 경로 초과 → null', () => {
+    const path = `/${'a'.repeat(SAFE_CALLBACK_PATH_MAX_LENGTH)}`;
+    expect(path.length).toBe(SAFE_CALLBACK_PATH_MAX_LENGTH + 1);
+    expect(getSafeCallbackPath(path)).toBeNull();
+  });
+
+  it('길이 상한: 디코딩 경로가 정확히 상한 이하이면 허용', () => {
+    const path = `/${'a'.repeat(SAFE_CALLBACK_PATH_MAX_LENGTH - 1)}`;
+    expect(path.length).toBe(SAFE_CALLBACK_PATH_MAX_LENGTH);
+    expect(getSafeCallbackPath(path)).toBe(path);
+  });
+
+  it('%25 포함 시 null (이중 인코딩·우회 시도 차단)', () => {
+    expect(getSafeCallbackPath('/x%252Fy')).toBeNull();
+    expect(getSafeCallbackPath('%25')).toBeNull();
+  });
+
+  it('CRLF·null byte 포함 시 null', () => {
+    expect(getSafeCallbackPath('/a\r\n/b')).toBeNull();
+    expect(getSafeCallbackPath('/a\n/b')).toBeNull();
+    expect(getSafeCallbackPath('/a\0/b')).toBeNull();
+  });
+
+  it('isAlreadyDecoded: true면 decodeURIComponent를 건너뜀', () => {
+    expect(getSafeCallbackPath('/plain', { isAlreadyDecoded: true })).toBe('/plain');
+    expect(getSafeCallbackPath('  /trim  ', { isAlreadyDecoded: true })).toBe('/trim');
   });
 });

--- a/src/lib/navigation/__tests__/safeCallbackPath.test.ts
+++ b/src/lib/navigation/__tests__/safeCallbackPath.test.ts
@@ -15,6 +15,13 @@ describe('getSafeCallbackPath', () => {
     expect(getSafeCallbackPath('/todos')).toBe('/todos');
     expect(getSafeCallbackPath('/todos?tab=1')).toBe('/todos?tab=1');
     expect(getSafeCallbackPath('%2Fprofile%2Fedit')).toBe('/profile/edit');
+    expect(getSafeCallbackPath('/share?url=https://example.com')).toBe(
+      '/share?url=https://example.com',
+    );
+  });
+
+  it('pathname에만 `://` 차단 (쿼리의 절대 URL은 허용)', () => {
+    expect(getSafeCallbackPath('/http://weird-path')).toBeNull();
   });
 
   it('오픈 리다이렉트 차단', () => {

--- a/src/lib/navigation/safeCallbackPath.ts
+++ b/src/lib/navigation/safeCallbackPath.ts
@@ -57,7 +57,15 @@ export function getSafeCallbackPath(
   // [7] 오픈 리다이렉트 방지 — 동일 출처 상대 경로만 허용
   if (!decoded.startsWith('/')) return null; // 절대 URL 차단
   if (decoded.startsWith('//')) return null; // protocol-relative URL 차단
-  if (decoded.includes('://')) return null; // 경로 중간의 절대 URL 차단
+
+  /**
+   * `://`는 pathname에만 적용한다.
+   * 전체 문자열 기준이면 `/share?url=https://...` 같은 합법 쿼리까지 막힘.
+   * 스킴이 있는 절대 URL은 보통 `https?...`로 시작해 [7] 첫 줄에서 걸리고,
+   * `//host`는 [7] 둘째 줄에서 걸린다. pathname 안의 `://`는 희귀 이상 경로만 추가 차단.
+   */
+  const pathOnly = decoded.split(/[?#]/, 1)[0] ?? '';
+  if (pathOnly.includes('://')) return null;
 
   return decoded;
 }

--- a/src/lib/navigation/safeCallbackPath.ts
+++ b/src/lib/navigation/safeCallbackPath.ts
@@ -1,18 +1,63 @@
 /**
- * 로그인 후 이동할 내부 경로만 허용 (오픈 리다이렉트 방지).
- * 동일 출처 상대 경로(`/`로 시작, `//` 금지)만 통과.
+ * percent-encoding 된 `callbackUrl` 쿼리 파라미터 원시값 상한.
+ *
+ * [근거]
+ * - OAuth state 페이로드에 포함되므로 Google(2,048) 등 공급자 한계를 고려.
+ * - 실제 내부 경로가 이 길이를 넘길 일은 없으므로 512로 충분.
  */
-export function getSafeCallbackPath(raw: string | null): string | null {
+export const SAFE_CALLBACK_RAW_MAX_LENGTH = 512;
+
+/**
+ * 디코딩된 내부 경로 최대 길이.
+ *
+ * [근거]
+ * - 쿼리스트링 포함 복잡한 경로도 300자 이하가 현실적 상한.
+ * - 공격 표면 최소화를 위해 500으로 제한.
+ */
+export const SAFE_CALLBACK_PATH_MAX_LENGTH = 500;
+
+/**
+ * @param raw - URL에서 추출한 원시 문자열.
+ *   - `searchParams.get()`처럼 이미 1회 디코딩된 값이면 isAlreadyDecoded: true 전달.
+ *   - raw query string에서 직접 추출한 경우 false (기본값).
+ */
+export function getSafeCallbackPath(
+  raw: string | null,
+  { isAlreadyDecoded = false } = {},
+): string | null {
   if (raw == null) return null;
+
   const trimmed = raw.trim();
   if (!trimmed) return null;
+
+  // [1] 원시 길이 체크 (encoded 기준)
+  if (trimmed.length > SAFE_CALLBACK_RAW_MAX_LENGTH) return null;
+
+  // [2] 이중 인코딩 차단 — %25 자체가 포함된 경우 우회 시도로 간주
+  //     decoded 후 %2F → // 가 되는 패턴을 원천 차단
+  if (trimmed.includes('%25')) return null;
+
+  // [3] 디코딩
   let decoded: string;
   try {
-    decoded = decodeURIComponent(trimmed);
+    decoded = isAlreadyDecoded ? trimmed : decodeURIComponent(trimmed);
   } catch {
     return null;
   }
-  if (!decoded.startsWith('/') || decoded.startsWith('//')) return null;
-  if (decoded.includes('://')) return null;
+
+  // [4] 디코딩된 경로 길이 체크
+  if (decoded.length > SAFE_CALLBACK_PATH_MAX_LENGTH) return null;
+
+  // [5] CRLF Injection 방지
+  if (/[\r\n]/.test(decoded)) return null;
+
+  // [6] Null byte 방지
+  if (decoded.includes('\0')) return null;
+
+  // [7] 오픈 리다이렉트 방지 — 동일 출처 상대 경로만 허용
+  if (!decoded.startsWith('/')) return null; // 절대 URL 차단
+  if (decoded.startsWith('//')) return null; // protocol-relative URL 차단
+  if (decoded.includes('://')) return null; // 경로 중간의 절대 URL 차단
+
   return decoded;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,12 +4,17 @@ import type { NextRequest } from 'next/server';
 
 import { NextResponse } from 'next/server';
 import { buildCsp } from '@/config/csp';
+import { isAbortError } from '@/lib/auth/isAbortError';
+import { fetchWithTimeout } from '@/lib/fetchWithTimeout';
 import { isPublicPath } from '@/lib/navigation/publicPaths';
 import { getSafeCallbackPath } from '@/lib/navigation/safeCallbackPath';
 
-import { ALLOWED_ORIGINS, API_BASE_URL } from '@/constants/api';
+import { ALLOWED_ORIGINS, API_BASE_URL, API_PROXY_TIMEOUT_MS } from '@/constants/api';
 import { AUTH_CONFIG, isAuthRouteGuardEnabled } from '@/constants/auth-config';
-import { AUTH_MISSING_REFRESH_TOKEN_MESSAGE_KO } from '@/constants/error-message';
+import {
+  AUTH_MISSING_REFRESH_TOKEN_MESSAGE_KO,
+  AUTH_SERVICE_ERROR_MESSAGE_KO,
+} from '@/constants/error-message';
 
 /** 갱신 실패·액세스 토큰 없음 — 백엔드로 무인증 프록시하지 않음 */
 function proxyAuthRequiredResponse(): Response {
@@ -241,5 +246,16 @@ export async function forwardToBackend(request: Request, path: string): Promise<
     }
   }
 
-  return fetch(url, { method, headers, body });
+  try {
+    return await fetchWithTimeout(url, { method, headers, body }, API_PROXY_TIMEOUT_MS);
+  } catch (error) {
+    const status = isAbortError(error) ? 504 : 502;
+    return new Response(
+      JSON.stringify({ success: false, message: AUTH_SERVICE_ERROR_MESSAGE_KO }),
+      {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
 }


### PR DESCRIPTION
# 📋 PR 개요

> OAuth 시작/콜백 및 서버 인증 타임아웃/Abort 처리 흐름을 정리해, 로그인/회원가입 인증 안정성과 에러 처리 일관성을 높이기 위한 PR입니다.
- 관련 이슈: Closes #318 
- **PR 유형:**
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [x] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?  
> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

- OAuth 진입점을 명확히 분리하기 위해 `google/kakao start route`를 추가했습니다.
  - `src/app/api/auth/oauth/google/start/route.ts`
  - `src/app/api/auth/oauth/kakao/start/route.ts`
- OAuth 콜백/로그인/회원가입/세션 갱신 경로 전반에서 서버 인증 요청의 timeout/abort 처리와 에러 핸들링을 정리했습니다.
  - `src/app/api/auth/login/route.ts`
  - `src/app/api/auth/signup/route.ts`
  - `src/app/api/auth/oauth/*/callback/route.ts`
  - `src/lib/auth/refreshSession.server.ts`
  - `src/proxy.ts`
- 공통 유틸/상수화를 통해 인증 로직 중복을 줄였습니다.
  - `src/lib/auth/isAbortError.ts` (신규)
  - `src/lib/auth/oauth-state.ts` (신규)
  - `src/constants/api.ts`
  - `src/lib/auth/oauth-urls.ts`
- OAuth 백엔드 로그인 완료 흐름(`completeGoogleBackendLogin`, `completeKakaoBackendLogin`)을 일관된 형태로 리팩터링했습니다.
- 토큰 페어 파싱 타입 계약을 보강하고 테스트를 업데이트했습니다.
  - `src/lib/auth/parseTokenPairFromBackendJson.ts`
  - `src/lib/auth/__tests__/parseTokenPairFromBackendJson.test.ts`

**구현 이유**
- 기존에는 OAuth 시작/완료와 backend login 완료 로직이 분산되어 있어 에러 처리와 유지보수 비용이 컸습니다.
- start/callback 분리 + 공통 유틸 도입으로 책임 경계를 명확히 하고 재사용성을 높였습니다.
- timeout/abort를 공통 기준으로 정리해 네트워크 지연 상황에서 사용자 체감 실패를 더 예측 가능하게 만들었습니다.

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [x] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [x] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [x] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [x] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [x] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [x] 민감 정보 노출 없음 (token, password, key 등)
- [x] N+1 쿼리 발생 없음
- [x] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| 해당없음 | 해당없음 |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. Google/Kakao 로그인 버튼 클릭 시 `/api/auth/oauth/{provider}/start`가 호출되는지 확인
2. OAuth 인증 완료 후 callback route에서 backend login 완료 및 세션 쿠키 세팅 여부 확인
3. 네트워크 지연/중단 상황에서 timeout/abort 에러 메시지가 의도대로 노출되는지 확인
4. 일반 로그인/회원가입 API에서 동일한 timeout/abort 처리 규칙이 적용되는지 확인
5. `parseTokenPairFromBackendJson` 테스트 실행으로 타입 계약 검증
```

**예상 결과:**

- OAuth 시작/콜백 경로가 provider별로 일관되게 동작한다.
- timeout/abort 상황에서 비정상 무한대기 없이 실패가 명확히 처리된다.
- 토큰 파싱 실패/성공 케이스가 테스트로 보장된다.

---

## ⚠️ 리뷰어 참고사항

- 이번 PR은 인증 플로우 정리 범위가 넓어서, **route 단위 동작**보다 **공통 에러 처리 규칙(timeout/abort) 일관성**을 중심으로 봐주면 좋습니다.
- `DEV` 기준 포함 커밋:
  - `f3cefcf` 🔧 fix(auth): apiClient timeout/abort 기반 서버 인증 요청 수정
  - `0b73427` ✨ feat(auth): OAuth start route 및 서버 로직 통합
  - `552175b` ♻️ Refactor(Auth): OAuth backend login flow 표준화
  - `ae8f29e` ✅ test(auth): token pair parsing 타입 계약/테스트 정리

---

## 📎 참고 자료

- OAuth start route 추가:
  - `src/app/api/auth/oauth/google/start/route.ts`
  - `src/app/api/auth/oauth/kakao/start/route.ts`
- 주요 인증 라우트:
  - `src/app/api/auth/login/route.ts`
  - `src/app/api/auth/signup/route.ts`
  - `src/app/api/auth/oauth/google/callback/route.ts`
  - `src/app/api/auth/oauth/kakao/callback/route.ts`
- 공통 로직/유틸:
  - `src/lib/auth/refreshSession.server.ts`
  - `src/lib/auth/isAbortError.ts`
  - `src/lib/auth/oauth-state.ts`
  - `src/lib/auth/parseTokenPairFromBackendJson.ts`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * Google/Kakao 소셜 로그인 시작 엔드포인트 추가로 인증 흐름 간소화 및 리디렉션 안정성 향상.
  * 서버사이드 OAuth 상태 생성·검증 도입으로 안전한 반환 경로 보장.
  * 클라이언트/프록시 요청 타임아웃 설정 지원 추가.

* **버그 수정**
  * 로그인·회원가입·OAuth 오류 매핑 개선(중복계정/타임아웃/기타)으로 일관된 안내 제공.
  * 클라이언트 쿠키 기반 상태/반환 경로 저장 제거로 보안성 강화.
  * 콜백 경로 검증 강화로 오픈 리다이렉트 차단.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->