### PR TITLE
Feat/278 top scroll fab

### DIFF
--- a/src/app/(routers)/(board)/community/CommunityClient.tsx
+++ b/src/app/(routers)/(board)/community/CommunityClient.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
+import { ScrollToTop } from '@/components/common/ScrollToTop';
 import { EmptyState } from '@/components/EmptyState';
 import { ErrorFallback } from '@/components/ErrorFallback';
 import { Icon } from '@/components/icon/Icon';
@@ -89,6 +90,7 @@ export default function CommunityClient() {
   return (
     <div className="relative h-full w-full">
       <div className="h-full overflow-y-auto bg-gray-100 px-4 py-6 pb-24 md:px-8 md:py-12 md:pb-20 lg:pb-16">
+        <ScrollToTop />
         <div className="mx-auto w-full max-w-[1200px]">
           <h1 className="font-xl-semibold md:font-2xl-semibold mb-6 px-2 text-black md:mb-8">
             <Link href="/community" className="cursor-pointer">
@@ -130,7 +132,6 @@ export default function CommunityClient() {
           </div>
         </div>
       </div>
-
       <Link
         href="/community/new"
         aria-label="게시물 작성하기"

--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -14,6 +14,7 @@ import { formatDate } from '@/utils/date';
 
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
+import { ScrollToTop } from '@/components/common/ScrollToTop';
 import { ErrorFallback } from '@/components/ErrorFallback';
 
 import { useDeletePost, useGetComments, useGetPostById } from '../_api/communityQueries';
@@ -98,6 +99,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
         }}
       />
       <div className="h-full w-full overflow-y-auto bg-gray-100 px-4 py-4 md:px-8 md:py-10 lg:p-14">
+        <ScrollToTop />
         <div className="mx-auto w-full md:max-w-[636px] lg:max-w-[768px]">
           <div className="flex flex-col gap-10 rounded-3xl bg-white px-5 py-6 md:gap-14 md:p-10 lg:p-14">
             <div className="w-full">

--- a/src/app/(routers)/favorites/_components/FavoritesTab.tsx
+++ b/src/app/(routers)/favorites/_components/FavoritesTab.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { cn } from '@/lib';
 
+import { ScrollToTop } from '@/components/common/ScrollToTop';
 import TodoItem from '@/components/common/TodoItem';
 import { EmptyState } from '@/components/EmptyState';
 import { ErrorFallback } from '@/components/ErrorFallback';
@@ -72,6 +73,7 @@ export default function FavoritesTab() {
 
   return (
     <div className="flex h-full flex-col">
+      <ScrollToTop />
       <h1 className="font-xl-bold mb-6 hidden text-gray-800 md:block">
         찜한 할 일 <span className="text-orange-500">{data?.pages[0]?.totalCount ?? 0}</span>
       </h1>

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib';
+
+import { ArrowIcon } from '../icon/icons/Arrow';
+
+export function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(([entry]) => setVisible(!entry.isIntersecting), {
+      threshold: 0,
+    });
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const handleClick = () => {
+    sentinelRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <>
+      <div ref={sentinelRef} aria-hidden className="h-0 w-0" />
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label="상단으로 이동"
+        className={cn(
+          'fixed right-4 bottom-24 flex size-[52px] cursor-pointer items-center justify-center rounded-full bg-white shadow-lg transition-opacity duration-200 md:right-8',
+          visible ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+      >
+        <ArrowIcon direction="up" variant="default" />
+      </button>
+    </>
+  );
+}

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -20,7 +20,15 @@ export function ScrollToTop() {
   }, []);
 
   const handleClick = () => {
-    sentinelRef.current?.scrollIntoView({ behavior: 'smooth' });
+    let el: HTMLElement | null = sentinelRef.current?.parentElement ?? null;
+    while (el) {
+      if (el.scrollTop > 0) {
+        el.scrollTo({ top: 0, behavior: 'smooth' });
+        return;
+      }
+      el = el.parentElement;
+    }
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -38,6 +38,9 @@ export function ScrollToTop() {
         type="button"
         onClick={handleClick}
         aria-label="상단으로 이동"
+        aria-hidden={!visible}
+        tabIndex={visible ? 0 : -1}
+        disabled={!visible}
         className={cn(
           'fixed right-4 bottom-24 flex size-[52px] cursor-pointer items-center justify-center rounded-full bg-white shadow-lg transition-opacity duration-200 md:right-8',
           visible ? 'opacity-100' : 'pointer-events-none opacity-0',


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #278  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- `ScrollToTop` 공통 컴포넌트 구현
- 소통 게시판 목록 페이지, 상세 페이지, 찜한 할 일 페이지에 적용
- 
> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 스크롤 컨테이너가 `window`가 아닌 내부 `div`인 경우, 어떤 요소가 실제 스크롤을 담당하는지 컴포넌트 외부에서 알 수 없습니다.
- 컨텐츠 최상단에 높이 0인 센티넬 `div`를 두고, 이 요소가 뷰포트 밖으로 나가면 FAB을 표시하는 방식으로 스크롤 컨테이너를 특정하지 않아도 동작합니다.
- FAB 클릭 시에는 `sentinelRef.current`의 부모 요소를 순회하며 `scrollTop > 0`인 요소를 찾아 `scrollTo({ top: 0 })`을 호출합니다. 
- 이 방식 덕분에 컨테이너 ref를 prop으로 주입하지 않아도 되어 재사용성이 높습니다.

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)
<img width="1214" height="753" alt="스크린샷 2026-04-09 오전 10 03 33" src="https://github.com/user-attachments/assets/73f762f8-e404-489d-8999-61dad94ab53c" />
<img width="457" height="757" alt="스크린샷 2026-04-09 오전 10 03 45" src="https://github.com/user-attachments/assets/0780d667-4c1e-4ca0-9c03-ab28ad391323" />


---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 소통 게시판 목록 페이지에서 스크롤을 내린다.
2. 우측 하단에 상단 스크롤 FAB이 나타나는지 확인
3. FAB 클릭 시 최상단으로 부드럽게 이동하는지 확인
4. 소통 게시판 상세 페이지에서 동일하게 확인
5. 찜한 할 일 페이지에서 동일하게 확인
6. 모바일 / 태블릿 / 데스크탑 각 뷰에서 동작 및 위치를 확인
```

**예상 결과:**
- 스크롤이 최상단일 때 FAB 비표시 (opacity 0, pointer-events none)
- 스크롤을 내리면 FAB 페이드인 표시
- FAB 클릭 시 smooth scroll로 최상단 이동


---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->
- ScrollToTop은 반드시 스크롤 컨테이너 내부의 첫 번째 자식으로 배치해야 정상 동작합니다. 컨테이너 외부에 두면 센티넬 요소의 부모 순회로 실제 스크롤 요소를 찾지 못합니다.
- FAB 위치(fixed right-4 bottom-24)는 하단 네비게이션 바와 겹치지 않도록 조정되어 있습니다.

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 커뮤니티, 게시물 상세, 즐겨찾기 페이지에 '맨 위로' 버튼 추가
  * 스크롤 시 버튼이 자동 표시되며 클릭하면 부드럽게 페이지 최상단으로 이동 (페이지별 스크롤 컨테이너 감지 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->