### PR TITLE
Feat/328 post comment reply

### DIFF
--- a/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
+++ b/src/app/(routers)/(board)/community/[id]/PostDetailClient.tsx
@@ -72,7 +72,7 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
   if (!post) return <ErrorFallback onRetry={refetch} title="소통 게시판" />;
   if (!contentReady) return <PostDetailSkeleton />;
 
-  const { title, viewCount, createdAt, writer, commentCount } = post;
+  const { title, viewCount, createdAt, writer } = post;
 
   const kebabItems = [
     { label: '수정하기', onClick: () => router.push(`/community/${postId}/edit`) },
@@ -105,7 +105,11 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
           <div className="flex flex-col gap-10 rounded-3xl bg-white px-5 py-6 md:gap-14 md:p-10 lg:p-14">
             <div className="w-full">
               <div className="flex items-start gap-2">
-                <button className="cursor-pointer pt-0.5" aria-label="목록으로 이동" onClick={() => router.push('/community')}>
+                <button
+                  className="cursor-pointer pt-0.5"
+                  aria-label="목록으로 이동"
+                  onClick={() => router.push('/community')}
+                >
                   <Icon name="arrow" direction="left" />
                 </button>
                 <h1 className="font-base-semibold md:font-xl-semibold min-w-0 flex-1 pl-1 text-gray-800">
@@ -151,7 +155,6 @@ export function PostDetailClient({ postId }: PostDetailClientProps) {
 
             <CommentSection
               postId={postId}
-              totalCount={commentCount}
               userId={userId}
               isPostDeleting={isPostDeleting}
               onPendingChange={setIsCommentBusy}

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentEditForm.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentEditForm.tsx
@@ -33,7 +33,7 @@ export function CommentEditForm({
   const { mutate: updateComment, isPending } = useUpdateComment(postId, commentId);
 
   const onSubmit = ({ content }: CommentForm) => {
-    updateComment(content, {
+    updateComment(content.trim(), {
       onSuccess: () => {
         reset();
         onSuccess();

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentEditForm.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentEditForm.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { CommentForm } from './CommentInput';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { useUpdateComment } from '../../_api/communityQueries';
+import { CommentInput, commentSchema } from './CommentInput';
+
+interface CommentEditFormProps {
+  postId: number;
+  commentId: number;
+  initialContent: string;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export function CommentEditForm({
+  postId,
+  commentId,
+  initialContent,
+  onSuccess,
+  onCancel,
+}: CommentEditFormProps) {
+  const { register, handleSubmit, reset, watch } = useForm<CommentForm>({
+    resolver: zodResolver(commentSchema),
+    defaultValues: { content: initialContent },
+  });
+
+  const contentValue = watch('content');
+  const { mutate: updateComment, isPending } = useUpdateComment(postId, commentId);
+
+  const onSubmit = ({ content }: CommentForm) => {
+    updateComment(content, {
+      onSuccess: () => {
+        reset();
+        onSuccess();
+      },
+      onError: () => toast.error('댓글 수정에 실패했습니다.'),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2 pt-1.5">
+      <CommentInput
+        register={register('content')}
+        contentLength={contentValue?.length ?? 0}
+        variant="underline"
+      />
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            onCancel();
+          }}
+          disabled={isPending}
+          className="font-sm-semibold w-16 rounded-full border border-gray-300 px-[18px] py-[10px] text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          disabled={!contentValue?.trim() || contentValue === initialContent || isPending}
+          className="font-sm-semibold w-16 rounded-full bg-orange-500 px-[18px] py-[10px] text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          수정
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
@@ -16,8 +16,13 @@ interface CommentInputProps {
   register: UseFormRegisterReturn;
   contentLength?: number;
   disabled?: boolean;
-  variant?: 'create' | 'edit';
+  variant?: 'create' | 'underline';
 }
+
+const variantStyles = {
+  create: 'rounded-xl border border-gray-300 px-3 py-3 md:rounded-2xl md:px-4 md:py-4',
+  underline: 'border-b-2 border-gray-300 px-1 py-1.5',
+};
 
 export function CommentInput({
   register,
@@ -30,13 +35,9 @@ export function CommentInput({
   return (
     <div
       className={cn(
-        'flex min-w-0 flex-1 items-center rounded-xl border bg-white',
-        variant === 'edit' ? 'px-3 py-2.5' : 'px-3 py-3 md:rounded-2xl md:px-4 md:py-4',
-        isOverLimit
-          ? 'border-red-400 bg-red-50'
-          : variant === 'edit'
-            ? 'border-orange-500'
-            : 'border-gray-300',
+        'flex min-w-0 flex-1 items-center bg-white',
+        variantStyles[variant],
+        isOverLimit && 'border-red-400 bg-red-50',
       )}
     >
       <input

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentInput.tsx
@@ -30,7 +30,8 @@ export function CommentInput({
   return (
     <div
       className={cn(
-        'flex min-w-0 flex-1 items-center rounded-xl border bg-white px-3 py-3 md:rounded-2xl md:px-4 md:py-4',
+        'flex min-w-0 flex-1 items-center rounded-xl border bg-white',
+        variant === 'edit' ? 'px-3 py-2.5' : 'px-3 py-3 md:rounded-2xl md:px-4 md:py-4',
         isOverLimit
           ? 'border-red-400 bg-red-50'
           : variant === 'edit'

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -5,6 +5,7 @@ import type { CommentForm } from './CommentInput';
 
 import { useEffect, useRef, useState } from 'react';
 import { useDebouncedCallback } from '@/hooks/useDebounceCallback';
+import { cn } from '@/lib';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -13,6 +14,7 @@ import { formatRelativeTime } from '@/utils/formatRelativeTime';
 
 import { DeleteDialog } from '@/components/common/DeleteDialog';
 import { KebabMenu } from '@/components/common/KebabMenu';
+import { Icon } from '@/components/icon/Icon';
 import { HeartIcon } from '@/components/icon/icons/Heart';
 
 import {
@@ -28,12 +30,24 @@ interface CommentItemProps {
   isMyComment: boolean;
   onDelete: (commentId: number, options?: { onError?: () => void }) => void;
   isDeleting: boolean;
+  replies?: Comment[];
+  userId?: number;
+  isReply?: boolean;
 }
 
-export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: CommentItemProps) {
+export function CommentItem({
+  comment,
+  isMyComment,
+  onDelete,
+  isDeleting,
+  replies,
+  userId,
+  isReply = false,
+}: CommentItemProps) {
   const { content, createdAt, writer } = comment;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const [showReplies, setShowReplies] = useState(true);
 
   const { register, handleSubmit, reset, watch } = useForm<CommentForm>({
     resolver: zodResolver(commentSchema),
@@ -46,8 +60,14 @@ export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: Comm
     comment.postId,
     comment.id,
   );
-  const { mutate: createCommentLike, isPending: isLiking } = useCreateCommentLike(comment.postId, comment.id);
-  const { mutate: deleteCommentLike, isPending: isUnliking } = useDeleteCommentLike(comment.postId, comment.id);
+  const { mutate: createCommentLike, isPending: isLiking } = useCreateCommentLike(
+    comment.postId,
+    comment.id,
+  );
+  const { mutate: deleteCommentLike, isPending: isUnliking } = useDeleteCommentLike(
+    comment.postId,
+    comment.id,
+  );
   const isLikePending = isLiking || isUnliking;
 
   const isLikedRef = useRef(comment.isLiked);
@@ -84,7 +104,7 @@ export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: Comm
   }, 300);
 
   return (
-    <li className="flex flex-col gap-3">
+    <li className={cn('flex flex-col gap-4', isReply && 'pl-10')}>
       <DeleteDialog
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
@@ -102,73 +122,130 @@ export function CommentItem({ comment, isMyComment, onDelete, isDeleting }: Comm
           });
         }}
       />
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <WriterAvatar name={writer.name} image={writer.image} />
-          <span className="font-xs-regular md:font-sm-regular text-gray-500">{writer.name}</span>
-          {isMyComment && (
-            <span className="font-xs-medium rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-amber-700">
-              내 댓글
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <WriterAvatar name={writer.name} image={writer.image} size={isReply ? 'sm' : 'md'} />
+            <span
+              className={cn(
+                'text-gray-500',
+                isReply ? 'font-xs-regular' : 'font-xs-regular md:font-sm-regular',
+              )}
+            >
+              {writer.name}
             </span>
-          )}
+          </div>
+          {isMyComment && <KebabMenu items={kebabItems} disabled={isDeleting} />}
         </div>
-        {isMyComment && <KebabMenu items={kebabItems} disabled={isDeleting} />}
-      </div>
 
-      {isEditing ? (
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2">
-          <CommentInput
-            register={register('content')}
-            contentLength={contentValue?.length ?? 0}
-            variant="edit"
-          />
-          <div className="flex items-center justify-between">
-            <span className="font-xs-regular md:font-sm-regular text-gray-400">
-              {formatRelativeTime(createdAt)}
-            </span>
-            <div className="flex items-center gap-2">
+        {isEditing ? (
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2">
+            <CommentInput
+              register={register('content')}
+              contentLength={contentValue?.length ?? 0}
+              variant="edit"
+            />
+            <div className="flex items-center justify-between">
+              <span className="font-xs-regular md:font-sm-regular text-gray-400">
+                {formatRelativeTime(createdAt)}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsEditing(false);
+                    reset();
+                  }}
+                  disabled={isUpdating}
+                  className="font-sm-semibold w-16 rounded-full border border-gray-300 px-[18px] py-[10px] text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  취소
+                </button>
+                <button
+                  type="submit"
+                  disabled={!contentValue?.trim() || contentValue === content || isUpdating}
+                  className="font-sm-semibold w-16 rounded-full bg-orange-500 px-[18px] py-[10px] text-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  수정
+                </button>
+              </div>
+            </div>
+          </form>
+        ) : (
+          <div className="flex flex-col gap-2 pt-1 pl-8">
+            <p
+              className={cn(
+                'text-gray-700',
+                isReply
+                  ? 'font-xs-regular md:font-sm-regular'
+                  : 'font-sm-regular md:font-base-regular',
+              )}
+            >
+              {content}
+            </p>
+            <div className="flex items-center gap-3">
+              <span className="font-xs-regular md:font-sm-regular text-gray-400">
+                {formatRelativeTime(createdAt)}
+              </span>
               <button
                 type="button"
-                onClick={() => {
-                  setIsEditing(false);
-                  reset();
-                }}
-                disabled={isUpdating}
-                className="font-sm-semibold w-16 rounded-full border border-gray-300 px-[18px] py-[10px] text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={comment.isLiked ? '좋아요 취소' : '좋아요'}
+                onClick={handleLikeClick}
+                disabled={isLikePending}
+                className="flex items-center gap-1 text-gray-400 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                취소
+                <HeartIcon aria-hidden filled={comment.isLiked} width={16} height={16} />
+                {comment.likeCount > 0 && (
+                  <span className="font-xs-regular">{comment.likeCount}</span>
+                )}
               </button>
-              <button
-                type="submit"
-                disabled={!contentValue?.trim() || contentValue === content || isUpdating}
-                className="font-sm-semibold w-16 rounded-full bg-orange-500 px-[18px] py-[10px] text-white disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                수정
-              </button>
+              {!isReply && (
+                <button type="button" className="font-xs-regular text-gray-400">
+                  답글
+                </button>
+              )}
             </div>
           </div>
-        </form>
-      ) : (
-        <div className="flex flex-col gap-2">
-          <p className="font-sm-regular md:font-base-regular text-gray-700">{content}</p>
-          <div className="flex items-center gap-3">
-            <span className="font-xs-regular md:font-sm-regular text-gray-400">
-              {formatRelativeTime(createdAt)}
-            </span>
+        )}
+      </div>
+
+      {!isReply && replies && replies.length > 0 && (
+        <>
+          {!showReplies && (
             <button
               type="button"
-              aria-label={comment.isLiked ? '좋아요 취소' : '좋아요'}
-              onClick={handleLikeClick}
-              disabled={isLikePending}
-              className="flex items-center gap-1 text-gray-400 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={() => setShowReplies(true)}
+              className="font-xs-semibold flex items-center gap-1 text-gray-400"
             >
-              <HeartIcon aria-hidden filled={comment.isLiked} width={16} height={16} />
-              {comment.likeCount > 0 && (
-                <span className="font-xs-regular">{comment.likeCount}</span>
-              )}
+              <span>답글 {replies.length}개 보기</span>
+              <Icon name="arrow" direction="down" />
             </button>
-          </div>
-        </div>
+          )}
+          {showReplies && (
+            <div className="relative">
+              <ul className="flex flex-col gap-4 pt-1">
+                {replies.map((reply) => (
+                  <CommentItem
+                    key={reply.id}
+                    comment={reply}
+                    isMyComment={reply.userId === userId}
+                    onDelete={onDelete}
+                    isDeleting={isDeleting}
+                    isReply
+                  />
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={() => setShowReplies(false)}
+                className="font-xs-semibold mt-3 flex items-center gap-1 text-gray-400"
+              >
+                <span>답글 숨기기</span>
+                <Icon name="arrow" direction="up" />
+              </button>
+            </div>
+          )}
+        </>
       )}
     </li>
   );

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -2,8 +2,7 @@
 
 import type { Comment } from '../../types';
 
-import { useEffect, useRef, useState } from 'react';
-import { useDebouncedCallback } from '@/hooks/useDebounceCallback';
+import { useState } from 'react';
 import { cn } from '@/lib';
 import { toast } from 'sonner';
 
@@ -43,25 +42,19 @@ export function CommentItem({
   const [isEditing, setIsEditing] = useState(false);
   const [showReplies, setShowReplies] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
-
   const { mutate: toggleLike, isPending: isLikePending } = useToggleCommentLike(
     comment.postId,
     comment.id,
   );
-
-  const isLikedRef = useRef(comment.isLiked);
-  useEffect(() => {
-    isLikedRef.current = comment.isLiked;
-  }, [comment.isLiked]);
 
   const kebabItems = [
     { label: '수정하기', onClick: () => setIsEditing(true) },
     { label: '삭제하기', onClick: () => setDeleteDialogOpen(true), variant: 'danger' as const },
   ];
 
-  const handleLikeClick = useDebouncedCallback(() => {
-    toggleLike(isLikedRef.current);
-  }, 300);
+  const handleLikeClick = () => {
+    toggleLike(comment.isLiked);
+  };
 
   return (
     <li className={cn('flex flex-col gap-4', isReply && 'pl-10')}>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentItem.tsx
@@ -1,13 +1,10 @@
 'use client';
 
 import type { Comment } from '../../types';
-import type { CommentForm } from './CommentInput';
 
 import { useEffect, useRef, useState } from 'react';
 import { useDebouncedCallback } from '@/hooks/useDebounceCallback';
 import { cn } from '@/lib';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
 import { formatRelativeTime } from '@/utils/formatRelativeTime';
@@ -17,13 +14,10 @@ import { KebabMenu } from '@/components/common/KebabMenu';
 import { Icon } from '@/components/icon/Icon';
 import { HeartIcon } from '@/components/icon/icons/Heart';
 
-import {
-  useCreateCommentLike,
-  useDeleteCommentLike,
-  useUpdateComment,
-} from '../../_api/communityQueries';
+import { useToggleCommentLike } from '../../_api/communityQueries';
 import { WriterAvatar } from '../../_components/WriterAvatar';
-import { CommentInput, commentSchema } from './CommentInput';
+import { CommentEditForm } from './CommentEditForm';
+import { ReplyForm } from './ReplyForm';
 
 interface CommentItemProps {
   comment: Comment;
@@ -47,28 +41,13 @@ export function CommentItem({
   const { content, createdAt, writer } = comment;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [showReplies, setShowReplies] = useState(true);
+  const [showReplies, setShowReplies] = useState(false);
+  const [isReplying, setIsReplying] = useState(false);
 
-  const { register, handleSubmit, reset, watch } = useForm<CommentForm>({
-    resolver: zodResolver(commentSchema),
-    defaultValues: { content },
-  });
-
-  const contentValue = watch('content');
-
-  const { mutate: updateComment, isPending: isUpdating } = useUpdateComment(
+  const { mutate: toggleLike, isPending: isLikePending } = useToggleCommentLike(
     comment.postId,
     comment.id,
   );
-  const { mutate: createCommentLike, isPending: isLiking } = useCreateCommentLike(
-    comment.postId,
-    comment.id,
-  );
-  const { mutate: deleteCommentLike, isPending: isUnliking } = useDeleteCommentLike(
-    comment.postId,
-    comment.id,
-  );
-  const isLikePending = isLiking || isUnliking;
 
   const isLikedRef = useRef(comment.isLiked);
   useEffect(() => {
@@ -80,27 +59,8 @@ export function CommentItem({
     { label: '삭제하기', onClick: () => setDeleteDialogOpen(true), variant: 'danger' as const },
   ];
 
-  const onSubmit = ({ content }: CommentForm) => {
-    if (!isMyComment) {
-      toast.error('본인이 작성한 댓글만 수정할 수 있습니다.');
-      return;
-    }
-
-    updateComment(content, {
-      onSuccess: () => {
-        reset();
-        setIsEditing(false);
-      },
-      onError: () => toast.error('댓글 수정에 실패했습니다.'),
-    });
-  };
-
   const handleLikeClick = useDebouncedCallback(() => {
-    if (isLikedRef.current) {
-      deleteCommentLike();
-    } else {
-      createCommentLike();
-    }
+    toggleLike(isLikedRef.current);
   }, 300);
 
   return (
@@ -116,7 +76,6 @@ export function CommentItem({
             setDeleteDialogOpen(false);
             return;
           }
-
           onDelete(comment.id, {
             onError: () => toast.error('댓글 삭제에 실패했습니다. 다시 시도해주세요.'),
           });
@@ -139,40 +98,15 @@ export function CommentItem({
         </div>
 
         {isEditing ? (
-          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2">
-            <CommentInput
-              register={register('content')}
-              contentLength={contentValue?.length ?? 0}
-              variant="edit"
-            />
-            <div className="flex items-center justify-between">
-              <span className="font-xs-regular md:font-sm-regular text-gray-400">
-                {formatRelativeTime(createdAt)}
-              </span>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setIsEditing(false);
-                    reset();
-                  }}
-                  disabled={isUpdating}
-                  className="font-sm-semibold w-16 rounded-full border border-gray-300 px-[18px] py-[10px] text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  취소
-                </button>
-                <button
-                  type="submit"
-                  disabled={!contentValue?.trim() || contentValue === content || isUpdating}
-                  className="font-sm-semibold w-16 rounded-full bg-orange-500 px-[18px] py-[10px] text-white disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  수정
-                </button>
-              </div>
-            </div>
-          </form>
+          <CommentEditForm
+            postId={comment.postId}
+            commentId={comment.id}
+            initialContent={content}
+            onSuccess={() => setIsEditing(false)}
+            onCancel={() => setIsEditing(false)}
+          />
         ) : (
-          <div className="flex flex-col gap-2 pt-1 pl-8">
+          <div className="flex flex-col gap-2 pt-1 pl-9">
             <p
               className={cn(
                 'text-gray-700',
@@ -200,7 +134,11 @@ export function CommentItem({
                 )}
               </button>
               {!isReply && (
-                <button type="button" className="font-xs-regular text-gray-400">
+                <button
+                  type="button"
+                  onClick={() => setIsReplying((prev) => !prev)}
+                  className="font-xs-regular text-gray-400 hover:text-gray-600"
+                >
                   답글
                 </button>
               )}
@@ -208,6 +146,18 @@ export function CommentItem({
           </div>
         )}
       </div>
+
+      {!isReply && isReplying && (
+        <ReplyForm
+          postId={comment.postId}
+          parentId={comment.id}
+          onSuccess={() => {
+            setIsReplying(false);
+            setShowReplies(true);
+          }}
+          onCancel={() => setIsReplying(false)}
+        />
+      )}
 
       {!isReply && replies && replies.length > 0 && (
         <>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -3,8 +3,7 @@
 import type { Comment } from '../../types';
 import type { CommentForm } from './CommentInput';
 
-import { useEffect, useMemo } from 'react';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -13,9 +12,10 @@ import { useCreateComment, useDeleteComment, useGetComments } from '../../_api/c
 import { CommentInput, commentSchema } from './CommentInput';
 import { CommentItem } from './CommentItem';
 
+const VISIBLE_STEP = 5;
+
 interface CommentSectionProps {
   postId: number;
-  totalCount: number;
   userId: number | undefined;
   isPostDeleting?: boolean;
   onPendingChange?: (isPending: boolean) => void;
@@ -23,27 +23,17 @@ interface CommentSectionProps {
 
 export function CommentSection({
   postId,
-  totalCount,
   userId,
   isPostDeleting = false,
   onPendingChange,
 }: CommentSectionProps) {
-  const {
-    data: commentsData,
-    isError,
-    isFetching,
-    refetch,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useGetComments(postId);
+  const { data: commentsData, isError, isFetching, refetch } = useGetComments(postId);
 
   const { rootComments, repliesMap } = useMemo(() => {
-    const all = (commentsData?.pages ?? []).flatMap((page) => page.comments);
-    const unique = Array.from(new Map(all.map((c) => [c.id, c])).values());
-    const rootComments = unique.filter((c) => c.parentId === null);
+    const all = commentsData?.comments ?? [];
+    const rootComments = all.filter((c) => c.parentId === null);
     const repliesMap = new Map<number, Comment[]>();
-    unique
+    all
       .filter((c) => c.parentId !== null)
       .forEach((c) => {
         const parentId = c.parentId!;
@@ -52,6 +42,23 @@ export function CommentSection({
       });
     return { rootComments, repliesMap };
   }, [commentsData]);
+
+  const [visibleCount, setVisibleCount] = useState(VISIBLE_STEP);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setVisibleCount((prev) => (prev < rootComments.length ? prev + VISIBLE_STEP : prev));
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rootComments.length]);
 
   const { mutate: createComment, isPending: isCreating } = useCreateComment(postId);
   const { mutate: deleteComment, isPending: isDeleting } = useDeleteComment(postId);
@@ -69,24 +76,26 @@ export function CommentSection({
     onPendingChange?.(isCreating || isDeleting);
   }, [isCreating, isDeleting, onPendingChange]);
 
-  const { observerRef } = useInfiniteScroll({
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-  });
-
   const onSubmit = ({ content }: CommentForm) => {
-    createComment(content, {
-      onSuccess: () => reset(),
-      onError: () => toast.error('댓글 등록에 실패했습니다.'),
-    });
+    createComment(
+      { content },
+      {
+        onSuccess: () => reset(),
+        onError: () => toast.error('댓글 등록에 실패했습니다.'),
+      },
+    );
   };
+
+  const visibleComments = rootComments.slice(0, visibleCount);
+  const hasMore = visibleCount < rootComments.length;
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-0.5">
         <span className="font-base-semibold md:font-lg-semibold text-gray-800">댓글</span>
-        <span className="font-base-semibold md:font-lg-semibold text-orange-600">{totalCount}</span>
+        <span className="font-base-semibold md:font-lg-semibold text-orange-600">
+          {rootComments.length}
+        </span>
       </div>
 
       <form onSubmit={handleSubmit(onSubmit)} className="flex gap-3 md:gap-4">
@@ -114,7 +123,7 @@ export function CommentSection({
       ) : (
         <>
           <ul className="flex flex-col gap-8 md:gap-10">
-            {rootComments.map((comment) => (
+            {visibleComments.map((comment) => (
               <CommentItem
                 key={comment.id}
                 comment={comment}
@@ -126,7 +135,7 @@ export function CommentSection({
               />
             ))}
           </ul>
-          <div ref={observerRef} className="h-4" />
+          {hasMore && <div ref={sentinelRef} className="h-4" />}
         </>
       )}
     </div>

--- a/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/CommentSection.tsx
@@ -38,9 +38,19 @@ export function CommentSection({
     isFetchingNextPage,
   } = useGetComments(postId);
 
-  const comments: Comment[] = useMemo(() => {
+  const { rootComments, repliesMap } = useMemo(() => {
     const all = (commentsData?.pages ?? []).flatMap((page) => page.comments);
-    return Array.from(new Map(all.map((c) => [c.id, c])).values());
+    const unique = Array.from(new Map(all.map((c) => [c.id, c])).values());
+    const rootComments = unique.filter((c) => c.parentId === null);
+    const repliesMap = new Map<number, Comment[]>();
+    unique
+      .filter((c) => c.parentId !== null)
+      .forEach((c) => {
+        const parentId = c.parentId!;
+        if (!repliesMap.has(parentId)) repliesMap.set(parentId, []);
+        repliesMap.get(parentId)!.push(c);
+      });
+    return { rootComments, repliesMap };
   }, [commentsData]);
 
   const { mutate: createComment, isPending: isCreating } = useCreateComment(postId);
@@ -104,13 +114,15 @@ export function CommentSection({
       ) : (
         <>
           <ul className="flex flex-col gap-8 md:gap-10">
-            {comments.map((comment) => (
+            {rootComments.map((comment) => (
               <CommentItem
                 key={comment.id}
                 comment={comment}
                 isMyComment={comment.userId === userId}
                 onDelete={deleteComment}
                 isDeleting={isBusy}
+                replies={repliesMap.get(comment.id)}
+                userId={userId}
               />
             ))}
           </ul>

--- a/src/app/(routers)/(board)/community/[id]/_components/ReplyForm.tsx
+++ b/src/app/(routers)/(board)/community/[id]/_components/ReplyForm.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import type { CommentForm } from './CommentInput';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { useCreateComment } from '../../_api/communityQueries';
+import { CommentInput, commentSchema } from './CommentInput';
+
+interface ReplyFormProps {
+  postId: number;
+  parentId: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export function ReplyForm({ postId, parentId, onSuccess, onCancel }: ReplyFormProps) {
+  const { register, handleSubmit, reset, watch } = useForm<CommentForm>({
+    resolver: zodResolver(commentSchema),
+    defaultValues: { content: '' },
+  });
+
+  const contentValue = watch('content');
+  const { mutate: createReply, isPending } = useCreateComment(postId);
+
+  const onSubmit = ({ content }: CommentForm) => {
+    createReply(
+      { content, parentId },
+      {
+        onSuccess: () => {
+          reset();
+          onSuccess();
+        },
+        onError: () => toast.error('답글 등록에 실패했습니다.'),
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex items-center gap-2 pl-10">
+      <CommentInput
+        register={register('content')}
+        contentLength={contentValue?.length ?? 0}
+        variant="underline"
+      />
+      <div className="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            onCancel();
+          }}
+          disabled={isPending}
+          className="font-sm-semibold rounded-full border border-gray-300 px-4 py-2 text-gray-500 disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          disabled={!contentValue?.trim() || isPending}
+          className="font-sm-semibold rounded-full bg-orange-500 px-4 py-2 text-white disabled:opacity-50"
+        >
+          등록
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -6,7 +6,6 @@ import type {
   PostsResponse,
   SortOption,
 } from '../types';
-import type { InfiniteData } from '@tanstack/react-query';
 
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/apiClient';
@@ -74,8 +73,9 @@ export const useCreatePost = () => {
     onSuccess: (data) => {
       queryClient.setQueryData(communityQueryKeys.post(data.id), data);
       queryClient.setQueryData(communityQueryKeys.comments(data.id), {
-        pages: [{ comments: [], totalCount: 0, nextCursor: null }],
-        pageParams: [undefined],
+        comments: [],
+        totalCount: 0,
+        nextCursor: null,
       });
       queryClient.invalidateQueries({ queryKey: communityQueryKeys.posts() });
       router.replace(`/community/${data.id}`);
@@ -124,11 +124,11 @@ export const useCreateComment = (postId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (content: string) =>
+    mutationFn: ({ content, parentId }: { content: string; parentId?: number }) =>
       apiClient<Comment>(`/posts/${postId}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content }),
+        body: JSON.stringify({ content, ...(parentId !== undefined && { parentId }) }),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityQueryKeys.all });
@@ -138,16 +138,11 @@ export const useCreateComment = (postId: number) => {
 
 // 댓글 목록 조회
 export const useGetComments = (postId: number) => {
-  return useInfiniteQuery({
+  return useQuery({
     queryKey: communityQueryKeys.comments(postId),
-    queryFn: ({ pageParam }) =>
-      apiClient<CommentsResponse>(
-        `/posts/${postId}/comments?limit=5${pageParam ? `&cursor=${pageParam}` : ''}`,
-      ),
+    queryFn: () => apiClient<CommentsResponse>(`/posts/${postId}/comments`),
     staleTime: 1000 * 60 * 5,
     enabled: Number.isInteger(postId) && postId > 0,
-    initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage) => lastPage?.nextCursor ?? undefined,
   });
 };
 
@@ -183,71 +178,37 @@ export const useDeleteComment = (postId: number) => {
   });
 };
 
-const updateCommentLikeCache = (
-  queryClient: ReturnType<typeof useQueryClient>,
-  postId: number,
-  commentId: number,
-  liked: boolean,
-) => {
-  queryClient.setQueryData(
-    communityQueryKeys.comments(postId),
-    (old: InfiniteData<CommentsResponse>) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => ({
-          ...page,
-          comments: page.comments.map((c) =>
+// 댓글 좋아요 토글
+export const useToggleCommentLike = (postId: number, commentId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (isLiked: boolean) =>
+      apiClient<void>(`/posts/${postId}/comments/${commentId}/likes`, {
+        method: isLiked ? 'DELETE' : 'POST',
+      }),
+    onMutate: async (isLiked) => {
+      await queryClient.cancelQueries({ queryKey: communityQueryKeys.comments(postId) });
+      const previous = queryClient.getQueryData(communityQueryKeys.comments(postId));
+      queryClient.setQueryData(communityQueryKeys.comments(postId), (old: CommentsResponse) => {
+        if (!old) return old;
+        return {
+          ...old,
+          comments: old.comments.map((c) =>
             c.id === commentId
-              ? { ...c, isLiked: liked, likeCount: Math.max(0, c.likeCount + (liked ? 1 : -1)) }
+              ? {
+                  ...c,
+                  isLiked: !isLiked,
+                  likeCount: Math.max(0, c.likeCount + (isLiked ? -1 : 1)),
+                }
               : c,
           ),
-        })),
-      };
-    },
-  );
-};
-
-// 댓글 좋아요
-export const useCreateCommentLike = (postId: number, commentId: number) => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: () =>
-      apiClient<void>(`/posts/${postId}/comments/${commentId}/likes`, { method: 'POST' }),
-    onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: communityQueryKeys.comments(postId) });
-      const previous = queryClient.getQueryData(communityQueryKeys.comments(postId));
-      updateCommentLikeCache(queryClient, postId, commentId, true);
+        };
+      });
       return { previous };
     },
     onError: (_err, _vars, context) => {
       queryClient.setQueryData(communityQueryKeys.comments(postId), context?.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: communityQueryKeys.comments(postId) });
-    },
-  });
-};
-
-// 댓글 좋아요 취소
-export const useDeleteCommentLike = (postId: number, commentId: number) => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: () =>
-      apiClient<void>(`/posts/${postId}/comments/${commentId}/likes`, { method: 'DELETE' }),
-    onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: communityQueryKeys.comments(postId) });
-      const previous = queryClient.getQueryData(communityQueryKeys.comments(postId));
-      updateCommentLikeCache(queryClient, postId, commentId, false);
-      return { previous };
-    },
-    onError: (_err, _vars, context) => {
-      queryClient.setQueryData(communityQueryKeys.comments(postId), context?.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: communityQueryKeys.comments(postId) });
     },
   });
 };

--- a/src/app/(routers)/(board)/community/_api/communityQueries.ts
+++ b/src/app/(routers)/(board)/community/_api/communityQueries.ts
@@ -128,7 +128,7 @@ export const useCreateComment = (postId: number) => {
       apiClient<Comment>(`/posts/${postId}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content, ...(parentId !== undefined && { parentId }) }),
+        body: JSON.stringify({ content: content.trim(), ...(parentId !== undefined && { parentId }) }),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityQueryKeys.all });

--- a/src/app/(routers)/(board)/community/_components/WriterAvatar.tsx
+++ b/src/app/(routers)/(board)/community/_components/WriterAvatar.tsx
@@ -3,12 +3,20 @@
 import { useState } from 'react';
 import Image from 'next/image';
 
+const sizeMap = {
+  sm: 'size-6',
+  md: 'size-8',
+} as const;
+
+type AvatarSize = keyof typeof sizeMap;
+
 interface WriterAvatarProps {
   name: string;
   image: string | null;
+  size?: AvatarSize;
 }
 
-export function WriterAvatar({ name, image }: WriterAvatarProps) {
+export function WriterAvatar({ name, image, size = 'sm' }: WriterAvatarProps) {
   const [imageError, setImageError] = useState(false);
   const [prevImage, setPrevImage] = useState(image);
 
@@ -18,7 +26,7 @@ export function WriterAvatar({ name, image }: WriterAvatarProps) {
   }
 
   return (
-    <div className="size-5 shrink-0 overflow-hidden rounded-full bg-gray-200">
+    <div className={`${sizeMap[size]} shrink-0 overflow-hidden rounded-full bg-gray-200`}>
       {image && !imageError ? (
         <Image
           src={image}

--- a/src/app/(routers)/(board)/community/types.ts
+++ b/src/app/(routers)/(board)/community/types.ts
@@ -10,6 +10,7 @@ export interface Comment {
   id: number;
   userId: number;
   postId: number;
+  parentId: number | null;
   content: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #328  <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 댓글에 답글 버튼 클릭 시 대댓글 입력폼 노출, 대댓글 목록 토글(N개 보기 / 숨기기) 추가
- useCreateComment mutationFn에 parentId 옵셔널 파라미터 추가
- CommentEditForm, ReplyForm 분리 → 필요 시에만 마운트하여 불필요한 hook 호출 방지
- CommentInput variant edit → underline으로 통합 (variantStyles 객체 패턴 적용)
- WriterAvatar에 size props 추가 (sm / md)
- useCreateCommentLike + useDeleteCommentLike + updateCommentLikeCache → useToggleCommentLike 단일 훅으로 통합

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 현재 API가 댓글/대댓글을 혼합 반환하므로 useInfiniteQuery → useQuery로 전환 후 전체 fetch, 클라이언트에서 rootComments / repliesMap으로 분리
- sentinel 패턴(IntersectionObserver + visibleCount)으로 클라이언트 사이드 무한스크롤 구현
- PostDetailClient에서 totalCount props 제거, CommentSection 내부에서 직접 계산
- 기존 useInfiniteQuery 기반 캐시 구조(pages[])를 useQuery 단일 구조로 변경함에 따라 updateCommentLikeCache 내부 로직도 단순화

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)
<img width="1371" height="834" alt="스크린샷 2026-04-10 오전 10 33 13" src="https://github.com/user-attachments/assets/e7eeb95d-39f8-4c3a-946e-cce63eb2dbd4" />
<img width="1372" height="832" alt="스크린샷 2026-04-10 오전 10 33 33" src="https://github.com/user-attachments/assets/06776f78-6d23-4ef4-9dc5-216a3d513ed7" />


---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 소통게시판 게시글 상세 페이지 진입
2. 댓글의 "답글" 버튼 클릭 → 대댓글 입력폼 노출 확인
3. 대댓글 작성 후 등록 → "답글 N개 보기" 버튼 노출 확인
4. 답글 보기/숨기기 토글 확인
5. 댓글/대댓글 좋아요 버튼 클릭 → 즉시 UI 반영 확인
6. 네트워크 탭에서 좋아요 클릭 시 likes API 1회만 호출되는지 확인 (comments 재fetch 없음)
```

**예상 결과:**

- 대댓글 작성/조회/토글 정상 동작
- 좋아요 클릭 시 즉각적인 UI 반영
- 좋아요 API 호출 1회

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->
- 현재 API ?parentId= 쿼리 미지원으로 전체 댓글을 한 번에 fetch 후 클라이언트에서 분리하는 방식을 사용 중입니다. 백엔드 지원 시 서버 사이드 무한스크롤로 전환 예정입니다.
- 댓글 수가 많아질 경우 전체 fetch 방식의 성능 이슈가 발생할 수 있습니다.
---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 편집 UI 추가
  * 댓글 답글 작성 및 중첩 댓글 보기 추가
  * 아바타 크기 옵션(sm/md) 추가

* **개선 사항**
  * 댓글 목록 로딩 방식 개선(로컬 "더보기"로 점진 로드)
  * 좋아요 상호작용 단순화 및 응답성 향상
  * 댓글 입력 UI에 새로운 밑줄 스타일 옵션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->