### PR TITLE
Feat/340 favorites note ids

### DIFF
--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -1,6 +1,7 @@
 import type { PaginatedResponse } from '@/api/response';
 import type { QueryClient } from '@tanstack/react-query';
 
+import { favoritesQueryKeys } from '@/app/(routers)/favorites/_api/favoritesQueries';
 import { apiClient } from '@/lib/apiClient.browser';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -127,6 +128,7 @@ export const useDeleteGoals = (options: { onSuccess?: () => void }) => {
       const id = payload.id;
       queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: [GOAL, id] });
+      queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
       options?.onSuccess?.();
     },
   });
@@ -164,6 +166,7 @@ export const usePatchGoals = () => {
     onSettled: (_, __, payload) => {
       queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: [GOAL, payload.id] });
+      queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
     },
   });
 };

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -4,6 +4,7 @@ import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 
 import { GOALS } from '@/api/goals';
 import { TODOS } from '@/api/todos';
+import { favoritesQueryKeys } from '@/app/(routers)/favorites/_api/favoritesQueries';
 import { apiClient } from '@/lib/apiClient.browser';
 import {
   keepPreviousData,
@@ -227,6 +228,7 @@ export const usePostNote = (options: { onSuccess?: () => void }) => {
       queryClient.invalidateQueries({ queryKey: [NOTES] });
       queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: [TODOS] });
+      queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
     },
   });
 };
@@ -284,6 +286,7 @@ export const useDeleteNote = () => {
       queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: [TODOS] });
       queryClient.invalidateQueries({ queryKey: [NOTE, payload.id] });
+      queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
     },
   });
 };

--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -309,6 +309,7 @@ export const usePostTodo = () => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [TODOS] });
+      queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
     },
   });
 };

--- a/src/app/(routers)/favorites/_api/favoritesQueries.ts
+++ b/src/app/(routers)/favorites/_api/favoritesQueries.ts
@@ -21,6 +21,7 @@ export interface Favorite {
       id: number;
       title: string;
     };
+    noteIds: number[];
   };
 }
 
@@ -28,7 +29,7 @@ export const toTask = (fav: Favorite) => ({
   id: fav.todo.id,
   teamId: fav.teamId,
   userId: fav.userId,
-  goalId: fav.todo.goal?.id ?? 0,
+  goalId: fav.todo.goal.id,
   title: fav.todo.title,
   done: fav.todo.done,
   fileUrl: null,
@@ -36,8 +37,8 @@ export const toTask = (fav: Favorite) => ({
   dueDate: '',
   createdAt: fav.createdAt,
   updatedAt: fav.createdAt,
-  goal: fav.todo.goal ?? { id: 0, title: '' },
-  noteIds: [],
+  goal: fav.todo.goal,
+  noteIds: fav.todo.noteIds ?? [],
   tags: [],
   favorites: true,
 });


### PR DESCRIPTION
# 📋 PR 개요

> 이 PR이 **왜** 필요한지, 어떤 문제를 해결하는지 한 줄로 요약해주세요.

- **관련 이슈:** Closes #340 <!-- 이슈가 없다면 삭제 -->
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
- 할일 생성, 노트 생성/삭제, 목표 수정/삭제 시 favoritesQueryKeys.all invalidate 추가
- toTask에서 noteIds: [] 하드코딩 → fav.todo.noteIds 실제 값 사용, goal 옵셔널 체이닝 제거

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?
- 찜한 할일의 노트 작성/삭제, 목표 수정/삭제 시 찜 페이지에 즉시 반영되지 않는 문제 존재
- 기존 API 응답에 noteIds가 없어 toTask에서 빈 배열로 하드코딩했으나, 백엔드에서 noteIds 필드가 추가됨에 따라 실제 값을 사용하도록 변경

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 찜한 할일이 있는 상태에서 테스트
2. 해당 할일에 노트 작성 후 찜 페이지 진입
3. 해당 할일에 노트 삭제 후 찜 페이지 진입
4. 해당 할일의 목표 제목 수정 후 찜 페이지 진입
5. 해당 할일의 목표 삭제 후 찜 페이지 진입
6. 새 할일 생성 후 찜하기 → 찜 페이지 진입
```

**예상 결과:**
- 노트 작성 후 찜 페이지에서 노트 연결 버튼 활성화
- 노트 삭제 후 찜 페이지에서 노트 연결 버튼 비활성화
- 목표 수정 시 찜 페이지의 목표명 즉시 반영
- 목표 삭제 시 찜 목록에서 해당 할일 제거
- 새로 생성한 할일 찜하기 시 찜 페이지 정상 반영

---

## ⚠️ 리뷰어 참고사항

> 특별히 집중해서 봐줬으면 하는 부분, 논의가 필요한 결정, 알려진 한계 등을 기재해주세요.

<!-- 예시: "이 부분은 임시 해결책입니다. 추후 #[이슈 번호]에서 개선 예정입니다." -->

---

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 목표, 노트, 할일 생성 또는 수정 시 즐겨찾기 목록이 최신 데이터로 동기화되도록 개선
  * 즐겨찾기 캐시 갱신 로직을 강화하여 사용자가 항상 최신 정보를 볼 수 있도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->