### PR TITLE
Feat/382 improve perf and a11y

### DIFF
--- a/src/app/(routers)/(dashboard)/dashboard/_components/MyProgress.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/MyProgress.tsx
@@ -5,18 +5,47 @@ import { useGetTodos } from '@/api/todos';
 import { useUserInfo } from '@/hooks/auth/useUserInfo';
 
 import { DonutProgress } from '@/components/common/DonutProgress';
+import { ErrorFallback } from '@/components/ErrorFallback';
+import { Skeleton } from '@/components/ui/skeleton';
 
 import { ProgressPercentage } from './ProgressPercentage';
+
+const MyProgressSkeleton = () => {
+  return (
+    <div className="my-progress-list flex flex-col gap-4">
+      <div className="my-progress-list-header flex justify-between">
+        <section className="flex items-center justify-between">
+          <h2 className="flex items-center gap-2">
+            <Skeleton variant="gray" className="size-8 rounded-xl md:size-8 lg:size-10" />
+            <Skeleton variant="gray" className="h-6 w-28 rounded-lg md:w-32 lg:h-7 lg:w-36" />
+          </h2>
+        </section>
+      </div>
+      <div className="relative w-full overflow-hidden rounded-[2.5rem] bg-blue-200 bg-linear-to-b from-transparent to-black/5 dark:bg-blue-300">
+        <div className="relative flex w-full items-center gap-x-5 px-6 py-12 md:gap-x-5 md:px-6 md:py-12 lg:gap-x-8 lg:px-12 lg:py-12">
+          <Skeleton
+            variant="gray"
+            className="size-23 shrink-0 rounded-full md:size-23 lg:size-40"
+          />
+          <div className="flex flex-col gap-y-2">
+            <Skeleton variant="gray" className="h-5 w-32 rounded-md md:w-40 lg:h-7 lg:w-52" />
+            <Skeleton variant="gray" className="h-9 w-18 rounded-md md:w-22 lg:h-12 lg:w-28" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export const MyProgress = () => {
   const user = useUserInfo();
   const name = user?.name ?? '손';
-  const { data: todos, isLoading, error } = useGetTodos({ limit: 100 });
+  const { data: todos, isLoading, error, refetch } = useGetTodos({ limit: 100 });
   const completedTodos = todos?.todos.filter((todo) => todo.done).length ?? 0;
   const totalTodos = todos?.todos.length ?? 0;
   const progress = totalTodos === 0 ? 0 : Number(Math.round((completedTodos / totalTodos) * 100));
-  if (isLoading) return <div>로딩중...</div>;
-  if (error || !todos) return <div>에러</div>;
+  if (isLoading) return <MyProgressSkeleton />;
+  if (error || !todos) return <ErrorFallback variant="compact" onRetry={() => void refetch()} />;
   /**
    * 필요 데이터: name, 전체 완료된 일, 완료되지 않은 할 일 (완료/(완료+미완료))
    */
@@ -42,9 +71,15 @@ export const MyProgress = () => {
         </section>
       </div>
       <div className="relative w-full overflow-hidden rounded-[2.5rem] bg-blue-200 bg-linear-to-b from-transparent to-black/5 transition-shadow duration-300 hover:shadow-[0_10px_40px_0_oklch(0.79_0.128_184.6/0.4)] dark:bg-blue-300">
-        <div
-          className="pointer-events-none absolute inset-0 z-0 bg-[url('/images/img-progress-mascot.svg')] bg-size-[auto_75%] bg-position-[right_-4%_bottom_0] bg-no-repeat opacity-40 md:bg-size-[auto_85%] lg:bg-size-[auto_90%] dark:opacity-35"
+        <Image
+          src="/images/img-progress-mascot.svg"
+          alt=""
           aria-hidden
+          width={480}
+          height={480}
+          priority
+          fetchPriority="high"
+          className="pointer-events-none absolute right-[-4%] bottom-0 z-0 h-[75%] w-auto opacity-40 md:h-[85%] lg:h-[90%] dark:opacity-35"
         />
         <div className="relative flex w-full items-center gap-x-5 md:gap-x-5 lg:gap-x-8">
           <div className="my-progress-list-progress-donut py-12 pl-6 md:py-12 md:pl-6 lg:py-12 lg:pl-12">

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoContainer.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoContainer.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { Todo } from '@/api/todos';
+
 import { useInfiniteTodos } from '@/api/todos';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
@@ -12,6 +14,10 @@ function matchesTodoSearch(title: string, query: string) {
   return title.toLowerCase().includes(q);
 }
 
+/** usePostTodo 낙관적 업데이트가 goalId/done 필터 없이 모든 TODOS 캐시에 삽입될 수 있어서 대시보드 목표별 뷰에서 잘못된 캐시 항목을 필터링 */
+const filterTodosForGoalColumn = (todos: Todo[], goalId: number, done: boolean) =>
+  todos.filter((t) => t.goalId === goalId && t.done === done);
+
 export function TodoContainer({
   goalId,
   searchQuery = '',
@@ -22,8 +28,16 @@ export function TodoContainer({
   const pendingQuery = useInfiniteTodos({ goalId, done: false, limit: PAGE_LIMIT });
   const doneQuery = useInfiniteTodos({ goalId, done: true, limit: PAGE_LIMIT });
 
-  const pendingTodosRaw = pendingQuery.data?.pages.flatMap((p) => p.todos) ?? [];
-  const doneTodosRaw = doneQuery.data?.pages.flatMap((p) => p.todos) ?? [];
+  const pendingTodosRaw = filterTodosForGoalColumn(
+    pendingQuery.data?.pages.flatMap((p) => p.todos) ?? [],
+    goalId,
+    false,
+  );
+  const doneTodosRaw = filterTodosForGoalColumn(
+    doneQuery.data?.pages.flatMap((p) => p.todos) ?? [],
+    goalId,
+    true,
+  );
 
   const todoList = pendingTodosRaw.filter((item) => matchesTodoSearch(item.title, searchQuery));
   const doneList = doneTodosRaw.filter((item) => matchesTodoSearch(item.title, searchQuery));

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
@@ -59,25 +59,51 @@ export default function TodoList({
         variantStyle[variant].container,
       )}
     >
-      <div className="flex w-full min-w-0 items-center space-x-1 md:space-x-2">
+      <div className="flex min-w-0 flex-1 items-center space-x-1 md:space-x-2">
         <Button variant="icon" size="none" onClick={checkButton}>
           <Icon name="checkBox" size={18} variant="ghost" className="shrink-0" checked={done} />
         </Button>
 
-        <Link
-          href={`/goals/${goalId}/todos/${id}`}
-          className="flex min-w-0 flex-1 items-center space-x-1 md:space-x-2"
-        >
-          <p
-            className={cn(
-              'font-sm-regular md:font-base-regular lg:font-lg-regular cursor-pointer truncate',
-              'hover:font-sm-semibold hover:md:font-base-semibold hover:lg:font-lg-semibold hover:truncate',
-              done && variant === 'recent' ? 'line-through' : '',
-              done && variant === 'completed' ? 'text-gray-500 line-through dark:text-black' : '',
-            )}
-          >
-            {title}
-          </p>
+        <Link href={`/goals/${goalId}/todos/${id}`} className="flex min-w-0 flex-1 items-center">
+          <div className="min-w-0 flex-1 overflow-hidden">
+            <p
+              className={cn(
+                'font-sm-regular md:font-base-regular lg:font-lg-regular cursor-pointer truncate group-hover:hidden',
+                done && variant === 'recent' ? 'line-through' : '',
+                done && variant === 'completed' ? 'text-gray-500 line-through dark:text-black' : '',
+              )}
+            >
+              {title}
+            </p>
+
+            <div className="hidden w-max min-w-full items-center overflow-hidden group-hover:flex">
+              <div className="animate-todo-marquee flex min-w-max">
+                <span
+                  className={cn(
+                    'font-sm-semibold md:font-base-semibold lg:font-lg-semibold pr-10 whitespace-nowrap',
+                    done && variant === 'recent' ? 'line-through' : '',
+                    done && variant === 'completed'
+                      ? 'text-gray-500 line-through dark:text-black'
+                      : '',
+                  )}
+                >
+                  {title}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'font-sm-semibold md:font-base-semibold lg:font-lg-semibold pr-10 whitespace-nowrap',
+                    done && variant === 'recent' ? 'line-through' : '',
+                    done && variant === 'completed'
+                      ? 'text-gray-500 line-through dark:text-black'
+                      : '',
+                  )}
+                >
+                  {title}
+                </span>
+              </div>
+            </div>
+          </div>
         </Link>
       </div>
       <ItemActionBar

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
@@ -5,11 +5,13 @@ import type { TodoListProps } from '@/app/(routers)/(todo)/goals/types';
 import Link from 'next/link';
 import { usePatchTodos } from '@/api/todos';
 import { useDebouncedCallback } from '@/hooks/useDebounceCallback';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { cn } from '@/lib';
 
 import { Icon } from '@/components/icon/Icon';
 import { Button } from '@/components/ui/button';
 
+import { shouldMarquee } from '../_constants/todos';
 import ItemActionBar from './ItemActionBar';
 
 /**
@@ -32,6 +34,11 @@ export default function TodoList({
   isFavorite,
   variant,
 }: TodoListPropsWithVairant) {
+  const isMdUp = useMediaQuery('(min-width: 768px)');
+  const isLgUp = useMediaQuery('(min-width: 1628px)');
+  const currentBreakpoint = isLgUp ? 'lg' : isMdUp ? 'md' : 'sm';
+  const enableMarquee = shouldMarquee(title, currentBreakpoint);
+
   /**
    * @description variant 값에 따라 스타일을 다르게 적용합니다
    */
@@ -68,7 +75,8 @@ export default function TodoList({
           <div className="min-w-0 flex-1 overflow-hidden">
             <p
               className={cn(
-                'font-sm-regular md:font-base-regular lg:font-lg-regular cursor-pointer truncate group-hover:hidden',
+                'font-sm-regular md:font-base-regular lg:font-lg-regular cursor-pointer truncate',
+                enableMarquee ? 'group-hover:hidden' : '',
                 done && variant === 'recent' ? 'line-through' : '',
                 done && variant === 'completed' ? 'text-gray-500 line-through dark:text-black' : '',
               )}
@@ -76,7 +84,12 @@ export default function TodoList({
               {title}
             </p>
 
-            <div className="hidden w-max min-w-full items-center overflow-hidden group-hover:flex">
+            <div
+              className={cn(
+                'hidden w-max min-w-full items-center overflow-hidden',
+                enableMarquee ? 'group-hover:flex' : '',
+              )}
+            >
               <div className="animate-todo-marquee flex min-w-max">
                 <span
                   className={cn(

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoListSection.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoListSection.tsx
@@ -76,7 +76,7 @@ export function TodoListSection({
   return (
     <section
       className={cn(
-        'flex min-h-0 flex-1 flex-col rounded-2xl p-4 md:p-4 lg:p-6',
+        'flex min-h-0 flex-1 flex-col rounded-2xl p-4 md:w-1/2 md:p-4 lg:w-1/2 lg:p-6',
         variant === 'completed'
           ? ''
           : 'bg-orange-100 text-black dark:bg-orange-300 dark:text-black',

--- a/src/app/(routers)/(dashboard)/dashboard/_constants/todos.ts
+++ b/src/app/(routers)/(dashboard)/dashboard/_constants/todos.ts
@@ -1,2 +1,15 @@
 /** 대시보드 "목표 별 할 일" — 해당 목표에서 보여줄 할 일 개수, 스크롤 시 동일 크기로 추가 로드 */
 export const PAGE_LIMIT = 4;
+
+export type DashboardBreakpoint = 'sm' | 'md' | 'lg';
+
+/** TodoList에서 텍스트 애니메이션 시킬 최소 글자 수(브레이크포인트별) */
+export const MARQUEE_CHAR_THRESHOLD: Record<DashboardBreakpoint, number> = {
+  sm: 18,
+  md: 24,
+  lg: 30,
+};
+
+/** TodoList에서 텍스트 애니메이션이 트리거될 조건 함수 */
+export const shouldMarquee = (title: string, breakpoint: DashboardBreakpoint) =>
+  title.trim().length > MARQUEE_CHAR_THRESHOLD[breakpoint];

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -218,6 +218,19 @@
 }
 
 @layer utilities {
+  @keyframes todo-marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(-50%);
+    }
+  }
+
+  .animate-todo-marquee {
+    animation: todo-marquee 10s linear infinite;
+  }
+
   .safe-padding {
     padding-top: env(safe-area-inset-top);
     padding-right: env(safe-area-inset-right);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,7 @@ export default function HomePage() {
           height={720}
           className="h-full w-full max-w-332 min-w-80 object-cover pt-18.5"
           priority
+          fetchPriority="high"
         />
       </section>
       <section className="features flex w-full flex-col items-center bg-orange-500 text-white lg:flex-row lg:items-center lg:justify-center lg:gap-6 dark:bg-orange-300 dark:text-black">
@@ -57,6 +58,7 @@ export default function HomePage() {
             height={720}
             className="h-full w-full max-w-167.5 min-w-80 object-cover pt-12 pb-3 lg:pb-0"
             priority
+            fetchPriority="high"
           />
         </aside>
       </section>


### PR DESCRIPTION
# 📋 PR 개요

> 대시보드 목표별 TODO 컬럼에서 잘못 섞여 보이던 항목을 필터링해 표시 정확도를 높이고, 진행률/리스트 UI를 성능 및 접근성 관점에서 개선

- **관련 이슈:** Closes #382 
- **PR 유형:**
  - [x] ✨ `feat` — 새로운 기능 추가
  - [ ] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [x] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?  
- 1) `TodoContainer`에서 낙관적 캐시 오염 방어 필터 추가  
- 2) `TodoList`에 브레이크포인트별 marquee 조건부 적용  
- 3) `MyProgress` 로딩/에러 fallback + background image 최적화

> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

- `TodoContainer`
  - `filterTodosForGoalColumn` 추가로 `goalId`/`done` 기준 재필터링.
  - 배경: `usePostTodo` 낙관적 업데이트가 모든 TODOS 캐시에 삽입될 수 있어 목표별 컬럼에서 이질 데이터가 보이는 문제를 방지하기 위함.
  - 대안으로 query key를 더 세분화하는 방식도 있으나, 현재 구조에선 렌더 직전 방어 필터가 가장 안전하고 영향 범위가 작음.

- `TodoList` + `dashboard/_constants/todos.ts` + `globals.css`
  - 브레이크포인트(`sm/md/lg`)별 marquee 임계치 상수화 (`shouldMarquee`).
  - 긴 제목일 때만 hover marquee 활성화, 짧은 제목은 기존 truncate 유지.
  - `@keyframes todo-marquee` 유틸 추가.
  - 이유: 텍스트 가독성/정보 노출 개선 + 불필요한 애니메이션 최소화.

- `MyProgress`
  - 단순 문자열 로딩/에러 UI를 `Skeleton`, `ErrorFallback`으로 교체하고 `refetch` 재시도 제공.
  - 배경 mascot을 CSS background에서 `next/image`로 전환하고 `priority`/`fetchPriority="high"` 적용.
  - 이유: 초기 체감 성능 개선(LCP 관련) + 실패 복구 UX 개선.

- `TodoListSection`
  - md/lg 구간에서 `w-1/2` 명시로 2열 레이아웃 안정화.

- `page.tsx`
  - 주요 이미지에 `fetchPriority="high"` 추가해 Above-the-fold 로딩 우선순위 명확화.

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [x] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [x] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [x] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [x] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [x] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [x] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [x] 민감 정보 노출 없음 (token, password, key 등)
- [x] N+1 쿼리 발생 없음
- [x] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| 목표 컬럼에 타 목표 TODO가 섞여 보일 수 있음 / 긴 텍스트 정보 손실 | 목표별 TODO 정합성 유지 / 긴 텍스트 hover marquee 표시 / Progress 스켈레톤·에러 복구 UI 적용 |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 대시보드 > 목표별 할 일 섹션 진입
2. 특정 goal에 todo를 추가/완료 처리 후 pending/completed 컬럼 확인
3. 긴 제목(임계치 초과) todo에 마우스 hover하여 marquee 동작 확인
4. 네트워크 차단/실패 상황에서 MyProgress fallback 및 재시도 버튼 확인
5. Lighthouse를 이용하여 홈(/) 진입 후 주요 이미지 로딩 우선순위 확인(LCP 영역)
```

**예상 결과:**

- 목표별 컬럼에 해당 `goalId`와 `done` 상태에 맞는 TODO만 노출됨
- 긴 제목만 marquee 애니메이션이 동작하고 짧은 제목은 truncate 유지
- MyProgress는 로딩 시 skeleton, 실패 시 compact fallback + retry 가능
- 홈 주요 이미지는 우선 로딩되어 초기 화면 표시가 안정적임

---

## ⚠️ 리뷰어 참고사항

- `fetchPriority="high"`는 `priority`와 함께 적용되어 우선순위를 더 명시적으로 준 변경입니다.
- TODO 캐시 필터링은 낙관적 업데이트 부작용을 UI 레벨에서 방어하고 있습니다.

---

## 📎 참고 자료

- [Next.js Image Component](https://nextjs.org/docs/app/api-reference/components/image)
- [MDN: fetchPriority](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 할 일 제목에 마크로 애니메이션 추가
  * 로딩 상태 및 에러 UI 개선

* **Style**
  * 반응형 대시보드 레이아웃 최적화
  * 마크로 애니메이션 스타일 추가

* **Performance**
  * 이미지 로딩 우선순위 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->