### PR TITLE
Feat/388 note layout

### DIFF
--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -236,12 +236,13 @@ export const usePostNote = (options: { onSuccess?: () => void }) => {
       context?.previousNotes.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
+      toast.error(NOTES_TEXT.NOTE_NEW_ERROR);
     },
 
     onSuccess: () => {
+      toast.success(NOTES_TEXT.NOTE_NEW_SUCCESS);
       options?.onSuccess?.();
     },
-
     onSettled: () => {
       // 성공/실패 모두 진짜 서버 데이터로 동기화
       queryClient.invalidateQueries({ queryKey: [NOTES] });

--- a/src/app/(routers)/(todo)/constants.ts
+++ b/src/app/(routers)/(todo)/constants.ts
@@ -48,6 +48,8 @@ export const NOTES_TEXT = {
   NO_MORE_NOTES: '노트를 더 작성해주세요',
   NOTE_EDIT_SUCCESS: '노트 수정을 완료했습니다.',
   NOTE_EDIT_ERROR: '노트 수정을 실패했습니다.',
+  NOTE_NEW_SUCCESS: '노트 등록을 완료했습니다.',
+  NOTE_NEW_ERROR: '노트 등록을 실패했습니다.',
 } as const;
 
 export const NOTES_SORT = {

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalHeader.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/GoalHeader.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import goalImage from '@/../public/images/small-goal.svg';
 import { useDeleteGoals, usePatchGoals } from '@/api/goals';
 import { GOAL_IMAGE, GOALS_TEXT } from '@/app/(routers)/(todo)/constants';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 
 import { ROUTES } from '@/constants/routes';
 import { DIALOG_VALUE, SELECT_VALUE } from '@/constants/ui-label';
@@ -148,7 +149,7 @@ export default function GoalHeader({ goalId, goalData }: GoalHeaderProps) {
                   type="button"
                   variant="default"
                   className="w-1/2"
-                  disabled={!title.trim() || title === goalData?.title}
+                  disabled={useDebouncedValue(!title.trim() || title === goalData?.title, 300)}
                 >
                   {DIALOG_VALUE.BUTTON.CONFIRM}
                 </Button>

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoList.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoList.tsx
@@ -2,6 +2,7 @@
 
 import type { TodoListProps } from '@/app/(routers)/(todo)/goals/types';
 
+import React, { useState } from 'react';
 import Link from 'next/link';
 import { usePatchTodos } from '@/api/todos';
 import { ItemActionBar } from '@/app/(routers)/(todo)/goals/[goalId]/_components/index';
@@ -23,10 +24,25 @@ export default function TodoList({
   isFavorite,
 }: TodoListProps) {
   const { mutate: checkTodo } = usePatchTodos();
+  const [localCheckTodo, setLocalCheckTodo] = useState<boolean>(done);
 
-  const checkButton = useDebouncedCallback(() => {
-    checkTodo({ id: id, done: !done });
+  const debouncedCheckButton = useDebouncedCallback((next: boolean) => {
+    if (next) {
+      checkTodo(
+        { id: id, done: !done },
+        {
+          onError: () => setLocalCheckTodo(done),
+        },
+      );
+    }
   }, 300);
+
+  const handleCheckButton = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const next = !done;
+    setLocalCheckTodo(next);
+    debouncedCheckButton(next);
+  };
 
   return (
     <div
@@ -36,8 +52,8 @@ export default function TodoList({
       )}
     >
       <div className="flex w-full min-w-0 items-center space-x-1 md:space-x-2">
-        <Button variant="icon" size="none" onClick={checkButton}>
-          <Icon name="checkBox" size={18} className="shrink-0" checked={done} />
+        <Button variant="icon" size="none" onClick={handleCheckButton}>
+          <Icon name="checkBox" size={18} className="shrink-0" checked={localCheckTodo} />
         </Button>
 
         <Link

--- a/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoSection.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/_components/TodoSection.tsx
@@ -44,7 +44,7 @@ export default function TodoSection({
     done,
     limit: 8,
   });
-
+  const MIN_TODOS_FOR_END_MESSAGE = 10;
   const todos = data?.pages.flatMap((page) => page.todos) ?? [];
 
   const { observerRef } = useInfiniteScroll({
@@ -98,9 +98,8 @@ export default function TodoSection({
                     isFavorite={todo.isFavorite}
                   />
                 ))}
-                {hasNextPage ? (
-                  <div ref={observerRef} className="h-5 w-full flex-shrink-0" />
-                ) : (
+                {hasNextPage && <div ref={observerRef} className="h-5 w-full flex-shrink-0" />}
+                {!hasNextPage && todos.length >= MIN_TODOS_FOR_END_MESSAGE && (
                   <div className="flex h-5 w-full flex-shrink-0 items-center justify-around">
                     <p className="font-sm-regular text-gray-400">{GOALS_TEXT.NO_MORE_TODOS}</p>
                   </div>

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/[noteId]/edit/_components/NoteEditContainer.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/[noteId]/edit/_components/NoteEditContainer.tsx
@@ -1,120 +1,27 @@
 'use client';
 
-import type { NoteEditContainerProps } from '@/app/(routers)/(todo)/goals/[goalId]/notes/types';
-
-import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useGetNote, usePatchNote } from '@/api/notes';
-import { NOTES_TEXT } from '@/app/(routers)/(todo)/constants';
+import { useGetNote } from '@/api/notes';
 import {
-  LinkEmbedOgImage,
-  NoteEditor,
-  NoteFormHeader,
-  SaveCheckToast,
+  NewNoteSkeleton,
+  NoteCommonFormat,
 } from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components';
-import SpeechComponent from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components/SpeechComponent';
-import { useLinkEmbed } from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useLinkEmbed';
-import {
-  NOTE_EDIT,
-  useNoteDraft,
-} from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useNoteDraft';
-import { useOgInfo } from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useOgInfo';
-import { useEditorWithContent } from '@/hooks/editor';
-import { cn } from '@/lib';
 
-export default function NoteEditContainer({ noteId }: NoteEditContainerProps) {
-  const router = useRouter();
-  const { data, isSuccess } = useGetNote({ id: noteId });
-  const { mutate } = usePatchNote({
-    onSuccess: () => {
-      router.back();
-    },
-  });
+import { ErrorFallback } from '@/components/ErrorFallback';
 
-  const [title, setTitle] = useState<string>(data?.title ?? '');
-  const [titleLength, setTitleLength] = useState<number>(0);
-  const [linkUrl, setLinkUrl] = useState<string | null>(null);
-  const { editor, json } = useEditorWithContent({
-    variant: 'note',
-    placeholder: NOTES_TEXT.NOTE_EDITOR_PLACEHOLDER,
-    initialContent: data ? JSON.stringify(data.content) : '',
-  });
-  const { data: linkData, isSuccess: linkSuccess } = useOgInfo(linkUrl);
-  const { showEmbed, handleLinkDelete, handleLinkClick } = useLinkEmbed({
-    editor,
-    linkData,
-    setLinkUrl,
-  });
-  const { saveCheck, saveDraft, loadDraft, clearDraft, elapsedSeconds } = useNoteDraft({
-    type: 'note-edit',
-    title,
-    linkUrl,
-    editor,
-    setTitle,
-    setTitleLength,
-    setLinkUrl,
-    noteId,
-  });
+export default function NoteEditContainer({ noteId }: { noteId: number }) {
+  const { data, isSuccess, isLoading, isError, refetch } = useGetNote({ id: noteId });
 
-  const onHandleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const titleValue = event.target.value;
-    setTitle(titleValue);
-    setTitleLength(titleValue.length);
-  };
-  const handleSubmit = () => {
-    mutate({
-      id: noteId,
-      content: JSON.parse(json),
-      title: title,
-      linkUrl: linkUrl ?? undefined,
-    });
-    const raw = localStorage.getItem(`${NOTE_EDIT}-${noteId}`);
-    if (raw) {
-      clearDraft();
-    }
-  };
-
+  if (isLoading) return <NewNoteSkeleton />;
+  if (isError) return <ErrorFallback onRetry={refetch} title={'노트 수정하기'} />;
   if (isSuccess)
     return (
-      <div className={cn('h-full w-fit', showEmbed && 'w-full flex-col justify-items-center')}>
-        <div className="relative flex h-full w-full flex-col items-center p-4 md:w-159 md:pt-12 md:pb-7.5 lg:w-192 lg:pt-18 lg:pb-15.5">
-          <NoteFormHeader
-            titleLength={titleLength}
-            clearDraft={clearDraft}
-            loadDraft={loadDraft}
-            saveDraft={saveDraft}
-            handleSubmit={handleSubmit}
-            edit
-            noteId={noteId}
-          />
-          <NoteEditor
-            editor={editor}
-            setLinkUrl={setLinkUrl}
-            title={title}
-            onHandleChange={onHandleChange}
-            titleLength={titleLength}
-            todoData={data.todo}
-            linkUrl={linkUrl}
-            linkData={linkData}
-            handleLinkDelete={handleLinkDelete}
-            handleLinkClick={handleLinkClick}
-          />
-        </div>
-        <SpeechComponent
-          loadDraft={loadDraft}
-          clearDraft={clearDraft}
-          className="bottom-20 md:hidden"
-          edit
-          noteId={noteId}
-        />
-        <SaveCheckToast saveCheck={saveCheck} elapsedSeconds={elapsedSeconds} />
-        <LinkEmbedOgImage
-          showEmbed={showEmbed}
-          linkUrl={linkUrl}
-          linkData={linkData}
-          linkSuccess={linkSuccess}
-          handleLinkClick={handleLinkClick}
-        />
-      </div>
+      <NoteCommonFormat
+        type={'edit'}
+        noteTitle={data?.title}
+        noteId={noteId}
+        todoData={data?.todo}
+        noteLinkUrl={data?.linkUrl}
+        noteContent={data?.content}
+      />
     );
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/[noteId]/edit/page.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/[noteId]/edit/page.tsx
@@ -1,4 +1,4 @@
-import NoteEditContainer from './_components/NoteEditContainer';
+import NoteEditContainer from '@/app/(routers)/(todo)/goals/[goalId]/notes/[noteId]/edit/_components/NoteEditContainer';
 
 export default async function NoteDetailPage({ params }: { params: Promise<{ noteId: string }> }) {
   const { noteId } = await params;

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteCommonFormat.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteCommonFormat.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import type { NoteCommonFormatProps } from '@/app/(routers)/(todo)/goals/[goalId]/notes/types';
+
+import React, { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { usePatchNote, usePostNote } from '@/api/notes';
+import { NOTES_TEXT } from '@/app/(routers)/(todo)/constants';
+import {
+  LinkEmbedOgImage,
+  NoteEditor,
+  NoteFormHeader,
+  SaveCheckToast,
+} from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components/index';
+import SpeechComponent from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components/SpeechComponent';
+import { useLinkEmbed } from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useLinkEmbed';
+import {
+  NOTE_CREATE,
+  NOTE_EDIT,
+  useNoteDraft,
+} from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useNoteDraft';
+import { useOgInfo } from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useOgInfo';
+import { useEditorWithContent } from '@/hooks/editor';
+import { cn } from '@/lib';
+
+import { MobileFormHeader } from '@/components/formHeader/MobileFormHeader';
+import { Toolbar } from '@/components/Toolbar';
+
+export default function NoteCommonFormat({
+  type,
+  noteTitle,
+  noteLinkUrl,
+  noteContent,
+  noteId,
+  todoData,
+}: NoteCommonFormatProps) {
+  const router = useRouter();
+
+  const { mutate: createNote } = usePostNote({
+    onSuccess: () => {
+      router.back();
+    },
+  });
+
+  const { mutate: patchNote } = usePatchNote({
+    onSuccess: () => {
+      router.back();
+    },
+  });
+
+  const newType = type === 'new';
+  const [title, setTitle] = useState<string>(!newType && noteTitle ? noteTitle : '');
+  const [titleLength, setTitleLength] = useState<number>(title.length);
+  const [linkUrl, setLinkUrl] = useState<string | null>(
+    !newType && noteLinkUrl ? noteLinkUrl : null,
+  );
+
+  const { data: linkData, isSuccess: linkSuccess } = useOgInfo(linkUrl);
+
+  const { editor, json } = useEditorWithContent({
+    variant: 'note',
+    placeholder: NOTES_TEXT.NOTE_EDITOR_PLACEHOLDER,
+    initialContent: !newType && noteContent ? JSON.stringify(noteContent) : undefined,
+  });
+
+  const { showEmbed, handleLinkDelete, handleLinkClick } = useLinkEmbed({
+    editor,
+    linkData,
+    setLinkUrl,
+  });
+
+  const { saveCheck, saveDraft, loadDraft, clearDraft, elapsedSeconds } = useNoteDraft({
+    type: newType ? 'note-create' : 'note-edit',
+    title,
+    linkUrl,
+    editor,
+    setTitle,
+    setTitleLength,
+    setLinkUrl,
+    noteId: newType ? undefined : noteId,
+  });
+
+  const onHandleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const titleValue = event.target.value;
+    setTitle(titleValue);
+    setTitleLength(titleValue.length);
+  };
+
+  const handleSubmit = () => {
+    if (newType) {
+      createNote({
+        todoId: todoData?.id,
+        title: title,
+        content: JSON.parse(json),
+        linkUrl: linkUrl ?? undefined,
+      });
+      const raw = localStorage.getItem(NOTE_CREATE);
+      if (raw) {
+        clearDraft();
+      }
+    } else {
+      if (!noteId) return;
+      patchNote({
+        id: noteId,
+        content: JSON.parse(json),
+        title: title,
+        linkUrl: linkUrl ?? undefined,
+      });
+      const raw = localStorage.getItem(`${NOTE_EDIT}-${noteId}`);
+      if (raw) {
+        clearDraft();
+      }
+    }
+  };
+
+  const toolbar = useMemo(
+    () => <Toolbar editor={editor} variant="note" onLinkConfirm={(url) => setLinkUrl(url)} />,
+    [editor, linkUrl],
+  );
+
+  return (
+    <div
+      className={cn(
+        'h-[calc(100dvh-68px)] min-h-0 w-fit',
+        showEmbed && 'w-full flex-col justify-items-center',
+      )}
+    >
+      <MobileFormHeader
+        isSubmitDisabled={titleLength === 0}
+        onCancel={saveDraft}
+        onSubmitClick={handleSubmit}
+        headerTitle={NOTES_TEXT.NOTE_CREATE}
+        secondaryLabel="임시저장"
+        submitLabel="등록"
+        toolbar={toolbar}
+      />
+      <div className="relative flex h-full w-full flex-col items-center p-4 md:w-159 md:pt-12 lg:w-192 lg:pt-18 lg:pb-15.5">
+        <NoteFormHeader
+          titleLength={titleLength}
+          clearDraft={clearDraft}
+          loadDraft={loadDraft}
+          saveDraft={saveDraft}
+          handleSubmit={handleSubmit}
+        />
+        <NoteEditor
+          toolbar={toolbar}
+          editor={editor}
+          title={title}
+          onHandleChange={onHandleChange}
+          titleLength={titleLength}
+          todoData={todoData}
+          linkUrl={linkUrl}
+          linkData={linkData}
+          handleLinkDelete={handleLinkDelete}
+          handleLinkClick={handleLinkClick}
+        />
+      </div>
+      <SpeechComponent
+        loadDraft={loadDraft}
+        clearDraft={clearDraft}
+        className="bottom-20 md:hidden"
+      />
+      <SaveCheckToast saveCheck={saveCheck} elapsedSeconds={elapsedSeconds} />
+      <LinkEmbedOgImage
+        showEmbed={showEmbed}
+        linkUrl={linkUrl}
+        linkData={linkData}
+        linkSuccess={linkSuccess}
+        handleLinkClick={handleLinkClick}
+      />
+    </div>
+  );
+}

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteEditor.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteEditor.tsx
@@ -11,12 +11,11 @@ import { EditorContent } from '@tiptap/react';
 import { EDITOR_LABELS } from '@/constants/ui-label';
 
 import { LinkEmbed } from '@/components/common/LinkEmbed';
-import { Toolbar } from '@/components/Toolbar';
 import { Input } from '@/components/ui/input';
 
 export default function NoteEditor({
   editor,
-  setLinkUrl,
+  toolbar,
   title,
   titleLength,
   onHandleChange,
@@ -31,8 +30,8 @@ export default function NoteEditor({
   const withSpace = getText().length;
   const withoutSpace = getText().replace(/\s/g, '').length;
   return (
-    <div className="mt-4 flex w-[343px] flex-1 flex-col overflow-hidden rounded-[24px] bg-white p-4 pb-8 md:w-full">
-      <Toolbar editor={editor} variant="note" onLinkConfirm={(url) => setLinkUrl(url)} />
+    <div className="mt-4 flex w-full min-w-[300px] flex-1 flex-col overflow-hidden rounded-[24px] bg-white p-4 pb-8">
+      <div className="hidden md:block">{toolbar}</div>
       <div className="mt-4 flex h-fit w-full items-center space-x-2 md:mt-7 md:space-x-3">
         <div className="flex w-full items-center space-x-0.5">
           <Image

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteFormHeader.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/NoteFormHeader.tsx
@@ -19,7 +19,7 @@ export default function NoteFormHeader({
   noteId,
 }: NoteFormHeaderProps) {
   return (
-    <div className="relative flex h-6 w-[343px] items-center justify-between md:h-10 md:w-full">
+    <div className="relative hidden h-6 w-[343px] items-center justify-between md:flex md:h-10 md:w-full">
       <h1 className="font-base-semibold md:font-xl-semibold lg:font-2xl-semibold">
         {edit ? NOTES_TEXT.NOTE_EDIT : NOTES_TEXT.NOTE_CREATE}
       </h1>

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/index.ts
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/_components/index.ts
@@ -7,3 +7,4 @@ export { default as NoteCard } from './NoteCard';
 export { NoteList } from './NoteList';
 export { default as NoteContainerSkeleton } from './NoteContainerSkeleton';
 export { default as NotesContainer } from './NotesContainer';
+export { default as NoteCommonFormat } from './NoteCommonFormat';

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/new/page.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/new/page.tsx
@@ -1,30 +1,11 @@
 'use client';
 
-import React, { useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { usePostNote } from '@/api/notes';
+import { useSearchParams } from 'next/navigation';
 import { useGetTodo } from '@/api/todos';
-import { NOTES_TEXT } from '@/app/(routers)/(todo)/constants';
-import SpeechComponent from '@/app/(routers)/(todo)/goals/[goalId]/notes/_components/SpeechComponent';
-import { useLinkEmbed } from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useLinkEmbed';
-import {
-  NOTE_CREATE,
-  useNoteDraft,
-} from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useNoteDraft';
-import { useOgInfo } from '@/app/(routers)/(todo)/goals/[goalId]/notes/hooks/useOgInfo';
-import { useEditorWithContent } from '@/hooks/editor';
-import { cn } from '@/lib';
 
-import {
-  LinkEmbedOgImage,
-  NewNoteSkeleton,
-  NoteEditor,
-  NoteFormHeader,
-  SaveCheckToast,
-} from '../_components';
+import { NewNoteSkeleton, NoteCommonFormat } from '../_components';
 
 export default function NewNotePage() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const todoId: number = Number(searchParams.get('todoId'));
   const {
@@ -32,98 +13,7 @@ export default function NewNotePage() {
     isLoading: todoIsLoading,
     isSuccess: todoIsSuccess,
   } = useGetTodo({ id: todoId });
-  const { mutate: createNote } = usePostNote({
-    onSuccess: () => {
-      router.back();
-    },
-  });
-
-  const [title, setTitle] = useState<string>('');
-  const [titleLength, setTitleLength] = useState<number>(0);
-  const [linkUrl, setLinkUrl] = useState<string | null>(null);
-
-  const { data: linkData, isSuccess: linkSuccess } = useOgInfo(linkUrl);
-
-  const { editor, json } = useEditorWithContent({
-    variant: 'note',
-    placeholder: NOTES_TEXT.NOTE_EDITOR_PLACEHOLDER,
-  });
-
-  const { saveCheck, saveDraft, loadDraft, clearDraft, elapsedSeconds } = useNoteDraft({
-    type: 'note-create',
-    title,
-    linkUrl,
-    editor,
-    setTitle,
-    setTitleLength,
-    setLinkUrl,
-  });
-
-  const { showEmbed, handleLinkDelete, handleLinkClick } = useLinkEmbed({
-    editor,
-    linkData,
-    setLinkUrl,
-  });
-
-  const onHandleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const titleValue = event.target.value;
-    setTitle(titleValue);
-    setTitleLength(titleValue.length);
-  };
-
-  const handleSubmit = () => {
-    if (todoIsSuccess) {
-      createNote({
-        todoId: todoData?.id,
-        title: title,
-        content: JSON.parse(json),
-        linkUrl: linkUrl ?? undefined,
-      });
-      const raw = localStorage.getItem(NOTE_CREATE);
-      if (raw) {
-        clearDraft();
-      }
-    }
-  };
 
   if (todoIsLoading) return <NewNoteSkeleton />;
-  if (todoIsSuccess)
-    return (
-      <div className={cn('h-full w-fit', showEmbed && 'w-full flex-col justify-items-center')}>
-        <div className="relative flex h-full w-full flex-col items-center p-4 md:w-159 md:pt-12 md:pb-7.5 lg:w-192 lg:pt-18 lg:pb-15.5">
-          <NoteFormHeader
-            titleLength={titleLength}
-            clearDraft={clearDraft}
-            loadDraft={loadDraft}
-            saveDraft={saveDraft}
-            handleSubmit={handleSubmit}
-          />
-          <NoteEditor
-            editor={editor}
-            setLinkUrl={setLinkUrl}
-            title={title}
-            onHandleChange={onHandleChange}
-            titleLength={titleLength}
-            todoData={todoData}
-            linkUrl={linkUrl}
-            linkData={linkData}
-            handleLinkDelete={handleLinkDelete}
-            handleLinkClick={handleLinkClick}
-          />
-        </div>
-        <SpeechComponent
-          loadDraft={loadDraft}
-          clearDraft={clearDraft}
-          className="bottom-20 md:hidden"
-        />
-        <SaveCheckToast saveCheck={saveCheck} elapsedSeconds={elapsedSeconds} />
-        <LinkEmbedOgImage
-          showEmbed={showEmbed}
-          linkUrl={linkUrl}
-          linkData={linkData}
-          linkSuccess={linkSuccess}
-          handleLinkClick={handleLinkClick}
-        />
-      </div>
-    );
+  if (todoIsSuccess) return <NoteCommonFormat type={'new'} todoData={todoData} />;
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/notes/types.ts
+++ b/src/app/(routers)/(todo)/goals/[goalId]/notes/types.ts
@@ -1,4 +1,4 @@
-import type { Notes } from '@/api/notes';
+import type { Notes, TipTapDoc } from '@/api/notes';
 import type { Todo, TodoResponse } from '@/api/todos';
 import type { OgInfoResponse } from '@/components/common/LinkEmbed';
 import type { Ref } from 'react';
@@ -40,7 +40,7 @@ export interface NoteFormHeaderProps {
 
 export interface NoteEditorProps {
   editor: Editor | null;
-  setLinkUrl: React.Dispatch<React.SetStateAction<string | null>>;
+  toolbar: React.ReactNode;
   title: string;
   onHandleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   titleLength: number;
@@ -49,6 +49,15 @@ export interface NoteEditorProps {
   linkData: OgInfoResponse | undefined;
   handleLinkDelete: (event: React.MouseEvent<HTMLButtonElement>) => void;
   handleLinkClick: () => void;
+}
+
+export interface NoteCommonFormatProps {
+  type: 'edit' | 'new';
+  noteTitle?: string;
+  noteLinkUrl?: string;
+  noteContent?: TipTapDoc;
+  noteId?: number;
+  todoData: Pick<TodoResponse, 'id' | 'title' | 'done' | 'tags' | 'goal' | 'createdAt'>;
 }
 
 export interface SpeechComponentProps {
@@ -84,8 +93,4 @@ export interface UseNoteDraftProps {
   setTitleLength: React.Dispatch<React.SetStateAction<number>>;
   setLinkUrl: React.Dispatch<React.SetStateAction<string | null>>;
   noteId?: number;
-}
-
-export interface NoteEditContainerProps {
-  noteId: number;
 }

--- a/src/app/(routers)/(todo)/goals/[goalId]/todos/[todoId]/_components/TodoDetailContainer.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/todos/[todoId]/_components/TodoDetailContainer.tsx
@@ -14,7 +14,7 @@ export default function TodoDetailContainer({ todoId }: { todoId: number }) {
   if (isLoading) return <TodoDetailSkeleton />;
   if (isSuccess)
     return (
-      <div className="h-fit w-fit rounded-[28px] bg-white p-6">
+      <div className="my-auto h-fit w-fit rounded-[28px] bg-white p-6">
         <TodoDetailContent
           title={data.title}
           done={data.done ? GOALS_TEXT.DONE : GOALS_TEXT.TODO}

--- a/src/app/(routers)/(todo)/goals/[goalId]/todos/[todoId]/page.tsx
+++ b/src/app/(routers)/(todo)/goals/[goalId]/todos/[todoId]/page.tsx
@@ -2,9 +2,5 @@ import TodoDetailContainer from '@/app/(routers)/(todo)/goals/[goalId]/todos/[to
 
 export default async function TodoIdPage({ params }: { params: Promise<{ todoId: string }> }) {
   const { todoId } = await params;
-  return (
-    <div>
-      <TodoDetailContainer todoId={Number(todoId)} />
-    </div>
-  );
+  return <TodoDetailContainer todoId={Number(todoId)} />;
 }

--- a/src/app/(routers)/calendar/page.tsx
+++ b/src/app/(routers)/calendar/page.tsx
@@ -10,7 +10,7 @@ import { getCurrentUser } from '@/lib/auth/getCurrentUser.server';
 export default async function CalendarPage() {
   const userInfo: User | null = await getCurrentUser();
   return (
-    <div className="my-auto h-full w-full pb-16 md:flex md:h-fit md:items-center md:justify-center">
+    <div className="my-auto h-full w-full pb-16 md:flex md:h-fit md:items-center md:justify-center md:py-6 lg:py-10">
       <div className="relative flex h-fit w-full min-w-86 flex-col items-center bg-white md:w-159 md:space-y-6 md:bg-transparent lg:w-320 lg:space-y-4">
         <CalendarPageHead userInfo={userInfo} />
         <ScheduleCalendar />

--- a/src/app/(routers)/profile/_components/ProfileContainer.tsx
+++ b/src/app/(routers)/profile/_components/ProfileContainer.tsx
@@ -32,6 +32,7 @@ export default function ProfileContainer() {
     imageUrl,
     isImageChanged,
     handleImageSelect,
+    handleImageDelete,
     submitProfile,
     resetNickNameCheck,
   } = useProfileForm();
@@ -62,8 +63,21 @@ export default function ProfileContainer() {
   };
   return (
     <div className="flex h-fit w-full flex-col items-center rounded-[32px] bg-white p-5 md:px-8 md:py-10">
-      <ProfileImageSection imageUrl={imageUrl} onCropComplete={handleImageSelect} />
-      <div className="mt-8 w-full md:mt-12">
+      <ProfileImageSection
+        imageUrl={imageUrl}
+        onCropComplete={handleImageSelect}
+        oauthProvider={oauthProvider}
+      />
+      {!oauthProvider && (
+        <button
+          type={'button'}
+          className="font-xs-regular mt-2 cursor-pointer text-gray-300"
+          onClick={handleImageDelete}
+        >
+          프로필 이미지 삭제
+        </button>
+      )}
+      <div className="mt-5 w-full md:mt-9">
         <ProfileNameForm
           register={register}
           errors={errors}

--- a/src/app/(routers)/profile/_components/ProfileImageSection.tsx
+++ b/src/app/(routers)/profile/_components/ProfileImageSection.tsx
@@ -8,6 +8,7 @@ import { PROFILE_IMAGE } from '@/app/(routers)/profile/constants';
 export default function ProfileImageSection({
   imageUrl,
   onCropComplete,
+  oauthProvider,
 }: ProfileImageSectionProps) {
   return (
     <div className="relative h-fit w-fit">
@@ -19,9 +20,11 @@ export default function ProfileImageSection({
           className="object-cover"
         />
       </div>
-      <div className="absolute right-3 bottom-0 flex size-9 items-center justify-center rounded-[18px] bg-orange-500">
-        <ImageCropper onCropComplete={onCropComplete} />
-      </div>
+      {!oauthProvider && (
+        <div className="absolute right-3 bottom-0 flex size-9 items-center justify-center rounded-[18px] bg-orange-500">
+          <ImageCropper onCropComplete={onCropComplete} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(routers)/profile/hooks/useProfileForm.ts
+++ b/src/app/(routers)/profile/hooks/useProfileForm.ts
@@ -19,6 +19,7 @@ export function useProfileForm() {
   const queryClient = useQueryClient();
   const { data: userData } = useGetMe();
   const { mutateAsync: patchProfile } = usePatchProfile();
+  const originalImage = useRef<string | null>(null);
   const originalName = useRef('');
 
   const {
@@ -34,20 +35,28 @@ export function useProfileForm() {
   useEffect(() => {
     if (userData) {
       setValue(NAME, userData.name);
+      originalImage.current = userData.image;
       originalName.current = userData.name;
     }
   }, [userData, setValue]);
 
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [isImageDeleted, setIsImageDeleted] = useState(false);
   const firstImageUrl = useRef<string | null>(null);
 
   const handleImageSelect = (file: File) => {
     setImageFile(file);
+    setIsImageDeleted(false);
     const previewUrl = URL.createObjectURL(file);
     setImageUrl(previewUrl);
   };
-  const isImageChanged = imageFile !== null;
+  const handleImageDelete = () => {
+    setImageUrl(null);
+    setImageFile(null);
+    setIsImageDeleted(true);
+  };
+  const isImageChanged = isImageDeleted || imageFile !== null;
 
   useEffect(() => {
     if (userData?.image) {
@@ -77,9 +86,12 @@ export function useProfileForm() {
   const submitProfile = async () => {
     if (!isNameChanged && !isImageChanged) return;
 
-    const payload: { name?: string; image?: string } = {};
+    const payload: { name?: string; image?: string | null } = {};
     if (isNameChanged) payload.name = nameValue;
-
+    if (isImageDeleted) {
+      payload.image = null;
+      setIsImageDeleted(false);
+    }
     // 저장 시점에 S3 업로드
     if (isImageChanged && imageFile) {
       const uploadedUrl = await uploadImage(imageFile);
@@ -105,6 +117,7 @@ export function useProfileForm() {
     imageUrl,
     isImageChanged,
     handleImageSelect,
+    handleImageDelete,
     submitProfile,
     resetNickNameCheck: () => setNickNameCheck(false),
   };

--- a/src/app/(routers)/profile/types.ts
+++ b/src/app/(routers)/profile/types.ts
@@ -15,6 +15,7 @@ export interface ProfileNameFormProps {
 export interface ProfileImageSectionProps {
   imageUrl: string | null;
   onCropComplete: (file: File) => void;
+  oauthProvider: boolean;
 }
 export interface PasswordFormProps {
   control: Control<PasswordFormValues>;


### PR DESCRIPTION
# 📋 PR 개요

레이아웃 조정, 낙관적 업데이트 개선, 프로필 사진 삭제 기능 추가 등 UX 개선 및 리팩토링 작업입니다.

- **관련 이슈:** Closes #388 
- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [x] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [x] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
### ✨ 기능 추가
- 프로필 사진 삭제 기능 추가
- OAuth 로그인 시 이미지 편집 관련 컴포넌트 비노출 처리

### ⚡ 성능 / UX 개선
- 할일 체크 시 낙관적 업데이트 적용 — 유저 쪽에서 값이 먼저 반영되도록 로직 변경
- 목표 수정 시 확인 버튼 활성화 체크 로직에 디바운스 적용
- 총 할일 12개 이하일 때 '할일 더 생성해주세요' 문구 무한스크롤 마지막에 노출

### 🎨 레이아웃 / UI
- 목표 페이지 레이아웃 조정
- 캘린더 레이아웃 조정
- 노트 작성 페이지 모바일 레이아웃 수정 및 공통 컴포넌트 리팩토링
> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

<!-- 핵심 변경 로직이나 설계 결정이 있다면 설명해주세요 -->

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [ ] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [ ] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [ ] 함수/변수명이 의도를 명확히 전달함
- [ ] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [ ] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [ ] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [ ] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [ ] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [ ] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [ ] 민감 정보 노출 없음 (token, password, key 등)
- [ ] N+1 쿼리 발생 없음
- [ ] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| ![변경 전](https://placehold.co/320x240?text=Before) | ![변경 후](https://placehold.co/320x240?text=After) |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. ...
2. ...
3. ...
```

**예상 결과:**

- ...

---

## ⚠️ 리뷰어 참고사항
- [ ] 프로필 사진 삭제 후 저장 시 이미지 제거 확인
- [ ] OAuth 로그인 시 이미지 편집 UI 비노출 확인
- [ ] 할일 체크 시 즉시 UI 반영 확인
- [ ] 목표 수정 시 디바운스 후 확인 버튼 활성화 확인
- [ ] 모바일 노트 작성 페이지 레이아웃 확인
- [ ] 캘린더 / 목표 페이지 레이아웃 확인

## 📎 참고 자료

> 관련 문서, 기술 블로그, 스택오버플로우, 이슈 등 링크를 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 프로필 이미지 삭제 기능 추가
- 노트 생성 성공/오류 알림 추가

## 버그 수정
- OAuth 제공자의 프로필 이미지 편집 기능 비활성화

## 리팩토링
- 노트 생성 및 편집 인터페이스 통합
- 할일 목록 종료 메시지 조건부 표시(10개 이상)
- 목표 제목 편집 시 디바운스 적용
- 할일 체크박스 낙관적 업데이트 개선

## 스타일
- 캘린더 및 프로필 페이지 반응형 레이아웃 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->