### PR TITLE
Fix/394 safari rendering

### DIFF
--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
@@ -76,7 +76,7 @@ export default function TodoList({
             <p
               className={cn(
                 'font-sm-regular md:font-base-regular lg:font-lg-regular cursor-pointer truncate',
-                enableMarquee ? 'group-hover:hidden' : '',
+                enableMarquee ? 'group-focus-within:hidden group-hover:hidden' : '',
                 done && variant === 'recent' ? 'line-through' : '',
                 done && variant === 'completed' ? 'text-gray-500 line-through dark:text-black' : '',
               )}
@@ -87,7 +87,7 @@ export default function TodoList({
             <div
               className={cn(
                 'hidden w-max min-w-full items-center overflow-hidden',
-                enableMarquee ? 'group-hover:flex' : '',
+                enableMarquee ? 'group-focus-within:flex group-hover:flex' : '',
               )}
             >
               <div className="animate-todo-marquee flex min-w-max">

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoListSection.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoListSection.tsx
@@ -76,7 +76,7 @@ export function TodoListSection({
   return (
     <section
       className={cn(
-        'flex min-h-0 flex-1 flex-col rounded-2xl p-4 md:w-1/2 md:flex-none md:p-4 lg:w-1/2 lg:flex-none lg:p-6',
+        'flex min-h-0 min-w-0 flex-1 flex-col rounded-2xl p-4 md:min-w-0 md:flex-1 md:p-4 lg:min-w-0 lg:flex-1 lg:p-6',
         variant === 'completed'
           ? ''
           : 'bg-orange-100 text-black dark:bg-orange-300 dark:text-black',

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoListSection.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoListSection.tsx
@@ -76,7 +76,7 @@ export function TodoListSection({
   return (
     <section
       className={cn(
-        'flex min-h-0 flex-1 flex-col rounded-2xl p-4 md:w-1/2 md:p-4 lg:w-1/2 lg:p-6',
+        'flex min-h-0 flex-1 flex-col rounded-2xl p-4 md:w-1/2 md:flex-none md:p-4 lg:w-1/2 lg:flex-none lg:p-6',
         variant === 'completed'
           ? ''
           : 'bg-orange-100 text-black dark:bg-orange-300 dark:text-black',

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -204,8 +204,8 @@
   --blue-200: oklch(0.79 0.128 184.6);
   --blue-300: oklch(0.897 0.053 190.5);
 
-  --red-400: oklch(0.740 0.191 22.216);
-  --red-500: oklch(0.680 0.237 25.331);
+  --red-400: oklch(0.74 0.191 22.216);
+  --red-500: oklch(0.68 0.237 25.331);
 }
 
 * {
@@ -229,6 +229,12 @@
 
   .animate-todo-marquee {
     animation: todo-marquee 10s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-todo-marquee {
+      animation: none;
+    }
   }
 
   .safe-padding {

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -19,7 +19,8 @@ function SearchInput({
   return (
     <InputGroup
       className={cn(
-        'h-fit min-h-12 w-full min-w-fit justify-between rounded-full bg-transparent',
+        // min-w-0: 그리드/flex 자식이 셀을 넘지 않게 (Safari에서 min-w-fit 시 다음 열과 겹침 방지)
+        'h-fit min-h-12 w-full min-w-0 justify-between rounded-full bg-transparent',
         className,
       )}
     >

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -17,7 +17,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="input-group"
       role="group"
       className={cn(
-        'group/input-group border-input bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 relative flex h-9 w-full min-w-0 items-center rounded-4xl border transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-data-[align=block-end]:rounded-2xl has-data-[align=block-start]:rounded-2xl has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[textarea]:rounded-xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5',
+        'group/input-group border-input bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 relative flex h-9 w-full min-w-0 items-center rounded-4xl border transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-data-[align=block-end]:rounded-2xl has-data-[align=block-start]:rounded-2xl has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[textarea]:rounded-xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto has-[>[data-align=block-end]]:**:data-[slot=input-group-control]:pt-3 has-[>[data-align=block-start]]:**:data-[slot=input-group-control]:pb-3 has-[>[data-align=inline-end]]:**:data-[slot=input-group-control]:pr-1.5 has-[>[data-align=inline-start]]:**:data-[slot=input-group-control]:pl-1.5',
         className,
       )}
       {...props}
@@ -33,9 +33,9 @@ const inputGroupAddonVariants = cva(
         'inline-start': 'order-first pl-3 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem]',
         'inline-end': 'order-last pr-3 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem]',
         'block-start':
-          'order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-3 [.border-b]:pb-3',
+          'order-first w-full justify-start px-3 pt-3 group-has-[[data-slot=input-group-control]]/input-group:pt-3 [.border-b]:pb-3',
         'block-end':
-          'order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-3 [.border-t]:pt-3',
+          'order-last w-full justify-start px-3 pb-3 group-has-[[data-slot=input-group-control]]/input-group:pb-3 [.border-t]:pt-3',
       },
     },
     defaultVariants: {

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -118,15 +118,18 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, InputProps>(function 
   ref,
 ) {
   return (
-    <Input
-      ref={ref}
-      data-slot="input-group-control"
-      className={cn(
-        'flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent',
-        className,
-      )}
-      {...props}
-    />
+    // Input은 className을 내부 <input>에만 붙이고, 바깥은 래퍼 <div>라서 flex-1이 부모 flex에 안 먹음 → 래퍼에 flex-1·min-w-0 (Safari에서 addon 밀림 방지)
+    <div className="min-w-0 flex-1">
+      <Input
+        ref={ref}
+        data-slot="input-group-control"
+        className={cn(
+          'w-full min-w-0 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent',
+          className,
+        )}
+        {...props}
+      />
+    </div>
   );
 });
 InputGroupInput.displayName = 'InputGroupInput';


### PR DESCRIPTION
# 📋 PR 개요

> Safari·접근성·반응형에서 대시보드 할 일 영역(SearchInput/그리드, Todo 리스트 마퀴, 섹션 너비)이 깨지거나 동작이 어색한 문제 해결

- **관련 이슈:** Closes #394 
- **PR 유형:**
  - [x] ✨ `feat` — 새로운 기능 추가 *(키보드 포커스 시 마퀴, reduced-motion)*
  - [x] 🐛 `fix` — 버그 수정 *(Safari SearchInput 겹침·addon 위치, 레이아웃)*
  - [ ] ♻️ `refactor`
  - [x] 🎨 `style` — 포맷팅, 세미콜론 등 *(globals.css oklch 소수 자리, EOF newline)*
  - [ ] ⚡ `perf`
  - [ ] 🧪 `test`
  - [ ] 🔧 `chore`
  - [ ] 📝 `docs`

---

## 🔍 변경 사항 (What & Why)

**What**

1. **`SearchInput` / `InputGroupInput`** (`SearchInput.tsx`, `input-group.tsx`)  
   - `InputGroup`에 `min-w-fit` → `min-w-0`으로 변경해 그리드·flex 자식이 트랙을 넘지 않게 함.  
   - `Input`이 `className`을 내부 `<input>`에만 적용하는 구조라 `flex-1`이 부모 flex에 먹지 않던 문제를, `InputGroupInput`에서 `min-w-0 flex-1` 래퍼로 감싸고 입력은 `w-full min-w-0`으로 수정. Safari에서 검색창과 버튼 겹침·addon이 pill 밖으로 밀리는 현상 완화.

2. **`TodoList.tsx`**  
   - 마퀴 전환을 `group-hover`뿐 아니라 `group-focus-within`에도 적용해 키보드 포커스/탭으로도 동일하게 보이도록 함.

3. **`TodoListSection.tsx`**  
   - `md`/`lg`에서 `md:flex-none`, `lg:flex-none` 추가로 `flex-1`과 `w-1/2`가 같이 걸릴 때 레이아웃이 과도하게 늘어나지 않도록 조정.

4. **`globals.css`**  
   - `--red-400` / `--red-500` oklch 값 소수 자리 정리.  
   - `prefers-reduced-motion: reduce`일 때 `.animate-todo-marquee` 애니메이션 비활성화.  
   - 파일 끝 newline 정리.

**Why**

- WebKit은 `min-w-auto`/`min-w-fit`과 flex 중첩에서 크롬과 다르게 트랙 밖으로 밀리는 경우가 많아, 그리드 셀 안에서는 `min-w-0` + 실제 flex 참여하는 래퍼에 `flex-1`을 두는 편이 안전함.  
- 마는 호버만 켜두면 포인터 없이 쓰는 사용자에게 불공정해서 `focus-within`을 맞춤.  
- reduced motion은 OS 설정 존중.

---

## ✅ 체크리스트

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거 *(해당 없음)*
- [x] 하드코딩된 값 없음
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음
- [x] 새로운 타입/인터페이스 정의 완료 *(변경 없음)*
- [ ] `tsc --noEmit` 통과 확인 *(로컬에서 한 번 돌려주세요)*

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [x] 엣지 케이스 고려 완료 *(reduced motion, focus-within)*

### UI/UX (프론트엔드 변경 시)

- [x] 반응형 레이아웃 확인 (mobile / tablet / desktop) *(TodoListSection width/flex 조정 — 실기기 권장)*
- [x] 다크모드 / 라이트모드 대응 확인 *(기존 토큰 유지)*
- [x] 접근성(a11y) 기본 요건 충족 *(포커스 시 마퀴, reduced motion)*
- [ ] 로딩 / 에러 / 빈 상태 *(해당 없음)*

### 보안 & 성능

- [x] 민감 정보 노출 없음
- [x] N+1 쿼리 발생 없음
- [x] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| *(Safari: Goal 헤더 검색·추가 버튼 겹침 / 돋보기 밖으로 밀림)* | *(수정 후 동일 뷰)* |

---

## 🧪 테스트 방법

```text
1. 브랜치 체크아웃 후 pnpm dev, Safari(또는 WebKit)에서 대시보드 목표 섹션으로 이동
2. 검색창과「할 일 추가」버튼이 겹치지 않고, 돋보기 아이콘이 검색 pill 안쪽에 있는지 확인
3. 할 일 제목이 길어 마퀴가 켜지는 항목에서: 마우스 호버 + Tab으로 포커스 시 동일하게 마퀴 전환되는지 확인
4. macOS 시스템 설정 → 손쉬운 사용 → 디스플레이 → 동작 줄이기 켠 뒤 마퀴 애니메이션이 멈추는지 확인
5. md/lg 뷰포트에서 TodoListSection 너비·스크롤이 의도대로인지 확인
```

**예상 결과:**

- Safari에서 SearchInput 레이아웃 정상, addon 내부 정렬.
- 키보드만으로도 마퀴 토글 가능, reduced motion 시 마퀴 정지.
- 중단점에서 섹션이 과도하게 늘어나지 않음.

---

## ⚠️ 리뷰어 참고사항

- 없음

---

## 📎 참고 자료

- (필요 시) WebKit flex/grid `min-width: auto` 동작: [CSSWG / MDN `min-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 투두 리스트 마퀴 애니메이션이 이제 마우스 호버뿐만 아니라 키보드 포커스에도 반응합니다.
  * 시스템의 감소된 움직임 설정을 존중하도록 마퀴 애니메이션을 업데이트했습니다.

* **개선 사항**
  * 검색 입력 필드의 레이아웃 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->