### PR TITLE
Hotfix/408 goals progress

### DIFF
--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -3,6 +3,7 @@ import type { PaginatedResponse } from '@/api/response';
 import type { TagColor } from '@/utils/tag';
 import type { InfiniteData } from '@tanstack/react-query';
 
+import { GOALS } from '@/api/goals';
 import { NOTIFICATIONS } from '@/api/notifications';
 import { favoritesQueryKeys } from '@/app/(routers)/favorites/_api/favoritesQueryKeys';
 import { apiClient } from '@/lib/apiClient.browser';
@@ -154,7 +155,7 @@ export const usePatchTodos = () => {
   return useMutation({
     mutationFn: async (payload: PatchTodoPayload) => {
       const { id, ...rest } = payload;
-      const body = Object.fromEntries(Object.entries(rest).filter(([_, v]) => v !== undefined));
+      const body = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
       return await apiClient(`${TODOS_URL}/${id}`, { method: 'PATCH', body });
     },
     onMutate: async (payload: PatchTodoPayload) => {
@@ -203,6 +204,7 @@ export const usePatchTodos = () => {
       // 성공/실패 상관없이 최종적으로 서버 데이터로 동기화
       queryClient.invalidateQueries({ queryKey: [TODOS] });
       queryClient.invalidateQueries({ queryKey: [TODO, payload.id] });
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
       queryClient.invalidateQueries({ queryKey: [NOTIFICATIONS] });
     },
@@ -255,6 +257,7 @@ export const useDeleteTodos = () => {
     onSettled: (_, __, payload) => {
       queryClient.invalidateQueries({ queryKey: [TODOS] });
       queryClient.invalidateQueries({ queryKey: [TODO, payload.id] });
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
     },
   });
@@ -326,6 +329,7 @@ export const usePostTodo = () => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [TODOS] });
+      queryClient.invalidateQueries({ queryKey: [GOALS] });
       queryClient.invalidateQueries({ queryKey: favoritesQueryKeys.all });
     },
   });

--- a/src/app/(routers)/(dashboard)/dashboard/_components/ItemActionBar.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/ItemActionBar.tsx
@@ -2,7 +2,7 @@
 
 import type { VariantProps } from 'class-variance-authority';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useDeleteFavorite, usePostFavorite } from '@/api/favorites';
 import { useDeleteTodos } from '@/api/todos';
@@ -48,6 +48,10 @@ export default function ItemActionBar({
   const { mutate: deleteFavorite } = useDeleteFavorite();
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [localFavorite, setLocalFavorite] = useState(favorites);
+  useEffect(() => {
+    setLocalFavorite(favorites);
+  }, [favorites]);
 
   const selectValue = [
     {
@@ -84,13 +88,19 @@ export default function ItemActionBar({
     }
   };
 
-  const handleFavorite = useDebouncedCallback(() => {
-    if (favorites) {
-      deleteFavorite(id);
-    } else {
+  const debouncedFavoriteApi = useDebouncedCallback((nextFavorite: boolean) => {
+    if (nextFavorite) {
       postFavorite(id);
+    } else {
+      deleteFavorite(id);
     }
   }, 500);
+
+  const handleFavorite = () => {
+    const next = !localFavorite;
+    setLocalFavorite(next);
+    debouncedFavoriteApi(next);
+  };
 
   const variantStyle = {
     recent: {
@@ -168,11 +178,11 @@ export default function ItemActionBar({
         }}
         variant="icon"
         size="none"
-        aria-label={favorites ? '찜하기 취소' : '찜하기'}
-        aria-pressed={favorites}
+        aria-label={localFavorite ? '찜하기 취소' : '찜하기'}
+        aria-pressed={localFavorite}
       >
         <Icon
-          name={favorites ? 'filledStar' : 'outlineStar'}
+          name={localFavorite ? 'filledStar' : 'outlineStar'}
           variant={
             resolvedTheme === 'dark'
               ? 'white'

--- a/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
+++ b/src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import type { TodoListProps } from '@/app/(routers)/(todo)/goals/types';
+import type { MouseEvent } from 'react';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePatchTodos } from '@/api/todos';
 import { useDebouncedCallback } from '@/hooks/useDebounceCallback';
@@ -55,9 +57,21 @@ export default function TodoList({
     },
   };
   const { mutate: checkTodo } = usePatchTodos();
-  const checkButton = useDebouncedCallback(() => {
-    checkTodo({ id: id, done: !done });
-  }, 1000);
+  const [localDone, setLocalDone] = useState(done);
+  useEffect(() => {
+    setLocalDone(done);
+  }, [done]);
+
+  const debouncedPatchDone = useDebouncedCallback((nextDone: boolean) => {
+    checkTodo({ id, done: nextDone });
+  }, 300);
+
+  const handleCheckClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    const next = !localDone;
+    setLocalDone(next);
+    debouncedPatchDone(next);
+  };
   return (
     <div
       className={cn(
@@ -67,8 +81,14 @@ export default function TodoList({
       )}
     >
       <div className="flex min-w-0 flex-1 items-center space-x-1 md:space-x-2">
-        <Button variant="icon" size="none" onClick={checkButton}>
-          <Icon name="checkBox" size={18} variant="ghost" className="shrink-0" checked={done} />
+        <Button variant="icon" size="none" onClick={handleCheckClick}>
+          <Icon
+            name="checkBox"
+            size={18}
+            variant="ghost"
+            className="shrink-0"
+            checked={localDone}
+          />
         </Button>
 
         <Link href={`/goals/${goalId}/todos/${id}`} className="flex min-w-0 flex-1 items-center">
@@ -77,8 +97,10 @@ export default function TodoList({
               className={cn(
                 'font-sm-regular md:font-base-regular lg:font-lg-regular cursor-pointer truncate',
                 enableMarquee ? 'group-focus-within:hidden group-hover:hidden' : '',
-                done && variant === 'recent' ? 'line-through' : '',
-                done && variant === 'completed' ? 'text-gray-500 line-through dark:text-black' : '',
+                localDone && variant === 'recent' ? 'line-through' : '',
+                localDone && variant === 'completed'
+                  ? 'text-gray-500 line-through dark:text-black'
+                  : '',
               )}
             >
               {title}
@@ -94,8 +116,8 @@ export default function TodoList({
                 <span
                   className={cn(
                     'font-sm-semibold md:font-base-semibold lg:font-lg-semibold pr-10 whitespace-nowrap',
-                    done && variant === 'recent' ? 'line-through' : '',
-                    done && variant === 'completed'
+                    localDone && variant === 'recent' ? 'line-through' : '',
+                    localDone && variant === 'completed'
                       ? 'text-gray-500 line-through dark:text-black'
                       : '',
                   )}
@@ -106,8 +128,8 @@ export default function TodoList({
                   aria-hidden="true"
                   className={cn(
                     'font-sm-semibold md:font-base-semibold lg:font-lg-semibold pr-10 whitespace-nowrap',
-                    done && variant === 'recent' ? 'line-through' : '',
-                    done && variant === 'completed'
+                    localDone && variant === 'recent' ? 'line-through' : '',
+                    localDone && variant === 'completed'
                       ? 'text-gray-500 line-through dark:text-black'
                       : '',
                   )}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { clearAuthCookies, clearOAuthUserFlashCookie } from '@/lib/auth/cookies';
 
+/** HttpOnly 쿠키만 제거. localStorage/sessionStorage의 RQ·Zustand persist는 클라이언트 `performClientLogout`에서 비움. */
 export async function POST() {
   await clearAuthCookies();
   const res = NextResponse.json({ success: true as const });

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -3,9 +3,11 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { performClientLogout } from '@/lib/auth/performClientLogout';
+import { useQueryClient } from '@tanstack/react-query';
 
 /** `POST /api/auth/logout` + 클라이언트 정리 후 `/`로 이동 */
 export function useLogout() {
   const router = useRouter();
-  return useCallback(() => performClientLogout(router), [router]);
+  const queryClient = useQueryClient();
+  return useCallback(() => performClientLogout(router, queryClient), [router, queryClient]);
 }

--- a/src/lib/auth/performClientLogout.ts
+++ b/src/lib/auth/performClientLogout.ts
@@ -1,7 +1,10 @@
 'use client';
 
+import type { QueryClient } from '@tanstack/react-query';
+
 import { apiClient } from '@/lib/apiClient';
 import { clearOAuthClientState } from '@/lib/auth/clearOAuthClientState';
+import { clearQueryPersistStorage } from '@/providers/createQueryPersister';
 import { authUserStore } from '@/stores/authUserStore';
 
 type LogoutRouter = {
@@ -14,8 +17,12 @@ type LogoutRouter = {
  * 화면 라우트 없이 버튼·훅에서 직접 호출한다.
  *
  * @see `src/app/api/auth/logout/route.ts`
+ * @param queryClient - 있으면 메모리 RQ 캐시도 비움 (Persist 재기록으로 stale 데이터 남김 방지)
  */
-export async function performClientLogout(router: LogoutRouter): Promise<void> {
+export async function performClientLogout(
+  router: LogoutRouter,
+  queryClient?: QueryClient,
+): Promise<void> {
   try {
     await apiClient<{ success?: boolean }>('/logout', {
       method: 'POST',
@@ -25,6 +32,8 @@ export async function performClientLogout(router: LogoutRouter): Promise<void> {
   } catch {
     // BFF 실패해도 클라이언트 세션은 반드시 비움 (ApiClientError 시 unhandled rejection 방지)
   } finally {
+    queryClient?.clear();
+    clearQueryPersistStorage();
     clearOAuthClientState('google');
     clearOAuthClientState('kakao');
     authUserStore.getState().clearUser();


### PR DESCRIPTION
# 📋 PR 개요

> 대시보드 Todo/즐겨찾기 토글의 반응성을 개선하고, Todo 변경/로그아웃 이후 남던 stale 캐시(Goals, React Query persist)를 정리해 데이터 일관성 문제를 해결합니다.

- **PR 유형:** <!-- 해당하는 항목에 `x`를 표시하세요 -->
  - [x] ✨ `feat` — 새로운 기능 추가
  - [x] 🐛 `fix` — 버그 수정
  - [ ] ♻️ `refactor` — 기능 변경 없는 코드 개선
  - [ ] 🎨 `style` — 포맷팅, 세미콜론 등 (로직 변경 없음)
  - [ ] ⚡ `perf` — 성능 개선
  - [ ] 🧪 `test` — 테스트 코드 추가/수정
  - [ ] 🔧 `chore` — 빌드, 설정, 패키지 변경
  - [ ] 📝 `docs` — 문서 작성/수정

---

## 🔍 변경 사항 (What & Why)

> **What:** 무엇을 변경했나요?
> **Why:** 왜 이 방식으로 구현했나요? 대안은 무엇이었나요?

- `src/api/todos.ts`
  - `usePatchTodos`, `useDeleteTodos`, `usePostTodo`의 `onSettled`에서 `GOALS` 쿼리 무효화 추가
  - Todo 변경 후 Goals 진행률/집계가 갱신되지 않던 동기화 누락 해결

- `src/lib/auth/performClientLogout.ts`, `src/hooks/auth/useLogout.ts`
  - `performClientLogout(router, queryClient?)` 시그니처 확장
  - 로그아웃 `finally`에서 `queryClient.clear()` + `clearQueryPersistStorage()` 수행
  - 쿠키만 지우던 서버 로그아웃과 별개로 클라이언트 메모리/퍼시스트 캐시까지 확실히 제거

- `src/app/(routers)/(dashboard)/dashboard/_components/TodoList.tsx`
  - `done` prop 기반 즉시 반영 대신 `localDone` + `useEffect` 동기화 + `debouncedPatchDone`로 변경
  - 체크 클릭 시 `stopPropagation` 적용 및 UI 즉시 토글(낙관적 UX) 후 API 반영

- `src/app/(routers)/(dashboard)/dashboard/_components/ItemActionBar.tsx`
  - `favorites` prop 기반 렌더링 대신 `localFavorite` 상태 도입
  - 즐겨찾기 토글 시 로컬 UI 즉시 업데이트 후 디바운스 API 호출로 연타/지연 체감 개선

- `src/app/api/auth/logout/route.ts`
  - 서버는 HttpOnly 쿠키만 제거하고, RQ/Zustand persist 정리는 클라이언트에서 수행한다는 책임 분리 주석 추가

---

## ✅ 체크리스트

> PR 제출 전 반드시 확인해주세요.

### 코드 품질

- [x] 불필요한 `console.log`, 주석 아웃된 코드 제거
- [x] 하드코딩된 값 없음 (환경변수 또는 상수 사용)
- [x] 함수/변수명이 의도를 명확히 전달함
- [x] 중복 코드 없음 (DRY 원칙 준수)

### 타입 안전성 (TypeScript)

- [x] `any` 타입 사용 없음 (불가피한 경우 주석으로 사유 명시)
- [x] 새로운 타입/인터페이스 정의 완료
- [ ] `tsc --noEmit` 통과 확인

### 테스트

- [ ] 새로운 기능에 대한 테스트 작성 완료
- [ ] 기존 테스트 모두 통과 (`pnpm test`)
- [x] 엣지 케이스 고려 완료

### UI/UX (프론트엔드 변경 시)

- [ ] 반응형 레이아웃 확인 (mobile / tablet / desktop)
- [ ] 다크모드 / 라이트모드 대응 확인
- [x] 접근성(a11y) 기본 요건 충족 (alt, aria, keyboard nav)
- [x] 로딩 / 에러 / 빈 상태(empty state) 처리 완료

### 보안 & 성능

- [x] 민감 정보 노출 없음 (token, password, key 등)
- [x] N+1 쿼리 발생 없음
- [x] 불필요한 리렌더링 없음

---

## 🖼️ 스크린샷 / 화면 녹화 (UI 변경 시)

| 변경 전 | 변경 후 |
| --- | --- |
| <!--대시보드 체크/즐겨찾기 클릭 후 서버 응답 전까지 UI 반영 지연, Goals 진행률 갱신 누락 가능--> | <!--클릭 즉시 UI 반영(낙관적 토글), Todo 변이 후 Goals 쿼리 무효화로 진행률 동기화--> |

---

## 🧪 테스트 방법

> 리뷰어가 직접 기능을 검증할 수 있도록 재현 가능한 절차를 작성해주세요.

```text
1. 대시보드 진입 후 Todo 체크박스를 빠르게 여러 번 토글한다.
2. 같은 화면에서 즐겨찾기(별) 버튼을 빠르게 토글한다.
3. Goals 화면으로 이동해 진행률/집계가 Todo 변경과 함께 갱신되는지 확인한다.
4. 로그인 상태에서 로그아웃 후 다시 로그인한다.
5. 이전 사용자 세션의 Todo/즐겨찾기/Goals 캐시가 남지 않고 최신 데이터로 로드되는지 확인한다.
```

## 예상 결과
- 체크/즐겨찾기 버튼 클릭 시 UI가 즉시 반응한다.
- Todo 생성/수정/삭제 후 Goals 진행률이 stale 없이 갱신된다.
- 로그아웃 후 재로그인 시 이전 캐시가 잔존하지 않는다.

## 📎 참고 자료
- React Query Query Invalidation: https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation
- React Query QueryClient API (clear): https://tanstack.com/query/latest/docs/reference/QueryClient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 할일 항목의 완료 상태와 즐겨찾기 표시가 서버 응답 전에 즉시 UI에 반영됩니다.
* 로그아웃 시 캐시 데이터가 올바르게 정리됩니다.
* 할일 변경 시 목표 관련 데이터가 적절히 동기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->